### PR TITLE
Update permissions Pensjon

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -17,20 +17,20 @@ spec:
       rules:
         - application: pensjon-pen-q0
           namespace: teampensjon
+        - application: pensjon-pen-q0
+          namespace: pensjon-q0
         - application: pensjon-pen-q1
           namespace: teampensjon
+        - application: pensjon-pen-q1
+          namespace: pensjon-q1
         - application: pensjon-pen-q2
           namespace: teampensjon
-        - application: pensjon-pen-q4
-          namespace: teampensjon
+        - application: pensjon-pen-q2
+          namespace: pensjon-q2
         - application: pensjon-pen-q5
           namespace: teampensjon
-        - application: pensjon-pen-t0
-          namespace: teampensjon
-        - application: pensjon-pen-q2
-          namespace: teampensjon
-        - application: pensjon-pen-t4
-          namespace: teampensjon
+        - application: pensjon-pen-q5
+          namespace: pensjon-q5
     outbound:
       rules:
         - application: tp-q1


### PR DESCRIPTION
We are moving applications to new namespaces in order to lock down access to the test environments with production data.
Upcoming platform change makes it possible to lock down certain kubectl commands in given namespaces.

This PR is preparing namespace move for pen, psak, pselv and name change for pselv application (both pselv applications are going to gcp in the same namespace).

A cleanup PR will be made when the applications are moved.