### PR TITLE
propagate error details to upstream services

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/AppMetrics.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/AppMetrics.kt
@@ -73,6 +73,10 @@ class AppMetrics(
         getCounter(prefix, metric)!!.increment()
     }
 
+    fun incrementCounter(metric: String) {
+        meterRegistry.counter(metric).increment()
+    }
+
     fun incrementCounterWithTag(metric: String, tagName: String) {
         meterRegistry.counter("${APP_NAME}_${metric}", "tagname", tagName).increment()
     }
@@ -124,6 +128,8 @@ class AppMetrics(
         const val APP_TOTAL_SIMULERING_UFUL = APP_NAME + "_app_simulering_ufullstendig"
         const val APP_TOTAL_SIMULERING_FEIL = APP_NAME + "_app_simulering_feil"
         const val APP_TOTAL_SIMULERING_MANGEL = APP_NAME + "_app_simulering_mangel"
+        const val APP_TOTAL_SIMULERING_BRUKER_KVALIFISERER_IKKE = APP_NAME + "_app_simulering_kvalifiserer_ikke"
+        const val APP_TOTAL_SIMULERING_TP_ORDNING_STOTTES_IKKE = APP_NAME + "_app_simulering_tp_ordning_stottes_ikke"
         const val TP_TOTAL_SIMULERING_CALLS = APP_NAME + "_tp_simulering_calls_"
         const val TP_TOTAL_SIMULERING_TIME = APP_NAME + "_tp_simulering_time_"
         const val TP_LATEST_SIMULERING_TIME = APP_NAME + "_tp_simulering_time_latest_"

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/exceptions/BrukerKvalifisererIkkeTilTjenestepensjonException.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/exceptions/BrukerKvalifisererIkkeTilTjenestepensjonException.kt
@@ -1,0 +1,4 @@
+package no.nav.tjenestepensjon.simulering.exceptions
+
+class BrukerKvalifisererIkkeTilTjenestepensjonException(msg: String) : RuntimeException(msg) {
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/rest/SimuleringEndpoint.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/rest/SimuleringEndpoint.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonMappingException
 import no.nav.tjenestepensjon.simulering.AppMetrics
 import no.nav.tjenestepensjon.simulering.AppMetrics.Metrics.APP_NAME
+import no.nav.tjenestepensjon.simulering.AppMetrics.Metrics.APP_TOTAL_SIMULERING_TP_ORDNING_STOTTES_IKKE
+import no.nav.tjenestepensjon.simulering.AppMetrics.Metrics.APP_TOTAL_SIMULERING_BRUKER_KVALIFISERER_IKKE
 import no.nav.tjenestepensjon.simulering.AppMetrics.Metrics.APP_TOTAL_SIMULERING_CALLS
 import no.nav.tjenestepensjon.simulering.AppMetrics.Metrics.APP_TOTAL_SIMULERING_FEIL
 import no.nav.tjenestepensjon.simulering.AppMetrics.Metrics.APP_TOTAL_STILLINGSPROSENT_ERROR
@@ -32,8 +34,6 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.OK
-import org.springframework.http.HttpStatusCode
-import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -109,10 +109,12 @@ class SimuleringEndpoint(
             log.warn("""Request with nav-call-id ${getHeaderFromRequestContext(NAV_CALL_ID)}. Unable to map body to request.""")
             ResponseEntity.badRequest().build()
         } catch (e: LeveradoerNotFoundException) {
+            metrics.incrementCounter(APP_TOTAL_SIMULERING_TP_ORDNING_STOTTES_IKKE)
             log.warn("""Request with nav-call-id ${getHeaderFromRequestContext(NAV_CALL_ID)}. No supported TP-Ordning found.""")
             ResponseEntity.notFound().build()
         }
         catch (e: BrukerKvalifisererIkkeTilTjenestepensjonException){
+            metrics.incrementCounter(APP_TOTAL_SIMULERING_BRUKER_KVALIFISERER_IKKE)
             log.warn("""Request with nav-call-id ${getHeaderFromRequestContext(NAV_CALL_ID)}. Bruker kvalifiserer ikke til tjenestepensjon. ${e.message}""")
             ResponseEntity.status(HttpStatus.CONFLICT).body(e.message ?: "Bruker kvalifiserer ikke til tjenestepensjon")
         } catch (e: Throwable) {


### PR DESCRIPTION
Feilmelding blir med videre til PEN, der opprettes det en FEIL `SimulertPensjon` som blir med videre til PSELV med feilbeskrivelse, hvor det leses inn og, kanskje, vises til brukeren
Det kommer en PR til for PEN side for å lese response body og putte den i feilbeskrivelse.

```
} catch (HttpStatusCodeException e) {
            logger.warn("An error occurred when calling PEON-799 simulerTjenestepensjon", e);
            return new SimulerOffentligTjenestepensjonResponse(
                singletonList(new SimulertPensjon("FEIL", "" + e.getRawStatusCode(), e.getMessage()))
            );
        }
```