### PR TITLE
Make app run on local machine

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
@@ -37,7 +37,7 @@ class WebClientConfig {
         .filter { request, next ->
             next.exchange(
                 ClientRequest.from(request)
-                    .header(HttpHeaders.AUTHORIZATION, adClient.getToken(afpScope))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + adClient.getToken(afpScope))
                     .build()
             )
         }
@@ -56,7 +56,7 @@ class WebClientConfig {
         .filter { request, next ->
             next.exchange(
                 ClientRequest.from(request)
-                    .header(HttpHeaders.AUTHORIZATION, adClient.getToken(scope))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + adClient.getToken(scope))
                     .build()
             )
         }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/model/domain/pen/AFPOffentligLivsvarigYtelse.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/model/domain/pen/AFPOffentligLivsvarigYtelse.kt
@@ -2,4 +2,4 @@ package no.nav.tjenestepensjon.simulering.model.domain.pen
 
 import java.time.LocalDate
 
-data class AFPOffentligLivsvarigYtelse(val ar: Int, val belop: Double, val fom: LocalDate, val tom: LocalDate)
+data class AFPOffentligLivsvarigYtelse(val ar: Int, val belop: Double, val fom: LocalDate, val tom: LocalDate?)

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/model/domain/popp/AFPGrunnlagBeholdningPeriode.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/model/domain/popp/AFPGrunnlagBeholdningPeriode.kt
@@ -5,4 +5,4 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class AFPGrunnlagBeholdningPeriode(val beholdning: Int,  @JsonProperty("fraOgMedDato") val fom: LocalDate, @JsonProperty("tilOgMedDato") val tom: LocalDate)
+data class AFPGrunnlagBeholdningPeriode(val beholdning: Int,  @JsonProperty("fraOgMedDato") val fom: LocalDate, @JsonProperty("tilOgMedDato") val tom: LocalDate?)

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/AADClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/AADClient.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 class AADClient(
     @Value("\${azure.app.client.id}") clientId: String,
     @Value("\${azure.app.client.secret}") clientSecret: String,
-    @Value("\${azure.app.well.known.url}") authority: String
+    @Value("\${azure.app.well-known-url}") authority: String
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/AADClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/AADClient.kt
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Service
 
 @Service
 class AADClient(
-    @Value("\${AZURE_APP_CLIENT_ID}") clientId: String,
-    @Value("\${AZURE_APP_CLIENT_SECRET}") clientSecret: String,
-    @Value("\${AZURE_APP_WELL_KNOWN_URL}") authority: String
+    @Value("\${azure.app.client.id}") clientId: String,
+    @Value("\${azure.app.client.secret}") clientSecret: String,
+    @Value("\${azure.app.well.known.url}") authority: String
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,12 +5,8 @@ azure:
   app:
     client:
       id: 2fedaa48-77ae-46ab-9ab2-83b3951b8c05
-    well:
-      known:
-        url: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration
-  openid:
-    config:
-      issuer: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0
+    well-known-url: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration
+  openid-config-issuer: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0
 sts:
   url: https://security-token-service.dev.adeo.no
 tp:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,35 @@
+simulering:
+  security:
+    issuers: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0
+azure:
+  app:
+    client:
+      id: 2fedaa48-77ae-46ab-9ab2-83b3951b8c05
+    well:
+      known:
+        url: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration
+  openid:
+    config:
+      issuer: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0
+sts:
+  url: https://security-token-service.dev.adeo.no
+tp:
+  url: https://tp-q2.dev.intern.nav.no
+  scope: api://dev-fss.pensjonsamhandling.tp-q2/.default
+afp:
+  beholdning:
+    url: https://pensjon-opptjening-afp-api.intern.dev.nav.no
+    scope: api://dev-gcp.pensjonopptjening.pensjon-opptjening-afp-api/.default
+pen:
+  url: https://pensjon-pen-q2.dev.adeo.no
+  scope: api://dev-fss.pensjon-q2.pensjon-pen-q2/.default
+logging:
+  level:
+    no:
+      nav:
+        tjenestepensjon:
+          simulering: DEBUG
+    reactor:
+      netty:
+        http:
+          client: DEBUG

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -9,7 +9,7 @@ logging.level:
 
 simulering:
   security:
-    issuers: ${AZURE_OPENID_CONFIG_ISSUER},https://security-token-service.nais.preprod.local,https://security-token-service-t4.nais.preprod.local,https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/
+    issuers: ${azure.openid.config.issuer},https://security-token-service.nais.preprod.local,https://security-token-service-t4.nais.preprod.local,https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/
 klp:
   name: KLP
   implementation: REST

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -9,7 +9,7 @@ logging.level:
 
 simulering:
   security:
-    issuers: ${azure.openid.config.issuer},https://security-token-service.nais.preprod.local,https://security-token-service-t4.nais.preprod.local,https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/
+    issuers: ${azure.openid-config-issuer},https://security-token-service.nais.preprod.local,https://security-token-service-t4.nais.preprod.local,https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/
 klp:
   name: KLP
   implementation: REST

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ logging.level:
 
 simulering:
   security:
-    issuers: ${AZURE_OPENID_CONFIG_ISSUER},https://security-token-service.nais.adeo.no,https://navnob2c.b2clogin.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/
+    issuers: ${azure.openid.config.issuer},https://security-token-service.nais.adeo.no,https://navnob2c.b2clogin.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/
 spk:
   name: SPK
   implementation: REST

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ logging.level:
 
 simulering:
   security:
-    issuers: ${azure.openid.config.issuer},https://security-token-service.nais.adeo.no,https://navnob2c.b2clogin.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/
+    issuers: ${azure.openid-config-issuer},https://security-token-service.nais.adeo.no,https://navnob2c.b2clogin.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/
 spk:
   name: SPK
   implementation: REST

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,13 +34,13 @@ SERVICE_USER_PASSWORD: password
 azure:
   app:
     client:
-      id: bogus
+      id: ${AZURE_APP_CLIENT_ID:bogus}
     well:
       known:
-        url: bogus
+        url: ${AZURE_APP_WELL_KNOWN_URL:https://localhost:8080/bogus}
   openid:
     config:
-      issuer: https://localhost:8080/bogus
+      issuer: ${AZURE_OPENID_CONFIG_ISSUER:https://localhost:8080/bogus}
 sts:
   url: http://localhost:8080
 tp:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,12 +35,8 @@ azure:
   app:
     client:
       id: ${AZURE_APP_CLIENT_ID:bogus}
-    well:
-      known:
-        url: ${AZURE_APP_WELL_KNOWN_URL:https://localhost:8080/bogus}
-  openid:
-    config:
-      issuer: ${AZURE_OPENID_CONFIG_ISSUER:https://localhost:8080/bogus}
+    well-known-url: ${AZURE_APP_WELL_KNOWN_URL:https://localhost:8080/bogus}
+  openid-config-issuer: ${AZURE_OPENID_CONFIG_ISSUER:https://localhost:8080/bogus}
 sts:
   url: http://localhost:8080
 tp:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,9 +31,16 @@ security:
     url: http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd
 SERVICE_USER: serviceuser
 SERVICE_USER_PASSWORD: password
-AZURE_APP_CLIENT_ID: bogus
-AZURE_APP_CLIENT_SECRET: bogus
-AZURE_APP_WELL_KNOWN_URL: https://localhost:8080/bogus
+azure:
+  app:
+    client:
+      id: bogus
+    well:
+      known:
+        url: bogus
+  openid:
+    config:
+      issuer: https://localhost:8080/bogus
 sts:
   url: http://localhost:8080
 tp:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,9 +9,13 @@ sts:
 tp:
   url: http://localhost:8080
   scope: api://bogus
-AZURE_APP_CLIENT_ID: bogus
-AZURE_APP_CLIENT_SECRET: bogus
-AZURE_APP_WELL_KNOWN_URL: https://localhost:8080/bogus
+azure:
+  app:
+    client:
+      id: bogus
+      secret: bogus
+    well-known-url: https://localhost:8080/bogus
+  openid-config-issuer: https://localhost:8080/bogus
 provider:
   uri: http://localhost:9080/ekstern-pensjon-tjeneste-tjenestepensjonSimuleringWeb/sca/TjenestepensjonSimuleringWSEXP
 SERVICE_USER: serviceuser


### PR DESCRIPTION
Endringer for å kunne kjøre appen lokalt, og støtte (delvis) kallet `http://localhost:8080/simulering/afp-offentlig-livsvarig`.

- Definerer nødvendige properties (i `application-local.yml`)
- Støtter `null`-verdier i `tilOgMedDato`
- Legger til "Bearer " før JWT i auth-header

Endret også til å bruke konvensjonelle property-navn, f.eks. `azure.app.client.id` istedenfor `AZURE_APP_CLIENT_ID`.

For å kjøre appen lokalt må følgende gjøres i Run/Debug config:
- Active profiles: `preprod,local`
- Environment variable `AZURE_APP_CLIENT_SECRET` må angis