### PR TITLE
Hent afpbeholdningsgrunnlag fra dato når brukeren blir 62 år

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v3/afp/AFPOffentligLivsvarigSimuleringService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v3/afp/AFPOffentligLivsvarigSimuleringService.kt
@@ -10,6 +10,7 @@ import no.nav.tjenestepensjon.simulering.service.AFPBeholdningClient
 import no.nav.tjenestepensjon.simulering.service.PenClient
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class AFPOffentligLivsvarigSimuleringService(val afpBeholdningClient: AFPBeholdningClient, val penClient: PenClient) {
@@ -21,7 +22,7 @@ class AFPOffentligLivsvarigSimuleringService(val afpBeholdningClient: AFPBeholdn
         log.info("Henter delingstall for fødselsår: ${request.fodselsdato.year} og alder $alder")
         val dt = penClient.hentDelingstall(request.fodselsdato.year, alder)
 
-        val requestToAFPBeholdninger = SimulerAFPBeholdningGrunnlagRequest(request.fnr, request.fom, request.fremtidigeInntekter.map { InntektPeriode(it.fom, it.belop) })
+        val requestToAFPBeholdninger = SimulerAFPBeholdningGrunnlagRequest(request.fnr, LocalDate.of(request.fodselsdato.year + 62, 1, 1), request.fremtidigeInntekter.map { InntektPeriode(it.fom, it.belop) })
         log.info("Henter AFP beholdninger for request: $requestToAFPBeholdninger") //TODO fjern fnr før produksjon
         val afpBeholdningsgrunnlag = afpBeholdningClient.simulerAFPBeholdningGrunnlag(requestToAFPBeholdninger)
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v3/afp/AFPOffentligLivsvarigSimuleringService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v3/afp/AFPOffentligLivsvarigSimuleringService.kt
@@ -16,13 +16,14 @@ import java.time.LocalDate
 class AFPOffentligLivsvarigSimuleringService(val afpBeholdningClient: AFPBeholdningClient, val penClient: PenClient) {
     private val log = LoggerFactory.getLogger(javaClass)
     private val hoyesteAlderForDelingstall = Alder(70, 0)
+    private val tidligstMuligUttaksalder = 62
 
     fun simuler(request: SimulerAFPOffentligLivsvarigRequest): List<AFPOffentligLivsvarigYtelse> {
         val alder: Alder = bestemAlderForDelingstall(request)
         log.info("Henter delingstall for fødselsår: ${request.fodselsdato.year} og alder $alder")
         val dt = penClient.hentDelingstall(request.fodselsdato.year, alder)
 
-        val requestToAFPBeholdninger = SimulerAFPBeholdningGrunnlagRequest(request.fnr, LocalDate.of(request.fodselsdato.year + 62, 1, 1), request.fremtidigeInntekter.map { InntektPeriode(it.fom, it.belop) })
+        val requestToAFPBeholdninger = SimulerAFPBeholdningGrunnlagRequest(request.fnr, LocalDate.of(request.fodselsdato.year + tidligstMuligUttaksalder, 1, 1), request.fremtidigeInntekter.map { InntektPeriode(it.fom, it.belop) })
         log.info("Henter AFP beholdninger for request: $requestToAFPBeholdninger") //TODO fjern fnr før produksjon
         val afpBeholdningsgrunnlag = afpBeholdningClient.simulerAFPBeholdningGrunnlag(requestToAFPBeholdninger)
 


### PR DESCRIPTION
Vi vil alltid være interessert i AFP Beholdningsgrunnlag ved 62 år alder, fordi brukeren ikke skal ta ut pensjon tidligere, og vi ikke er interessert i å vite hvordan AFP Beholdningsgrunnlaget hadde sett ut før brukeren fylte 62.