### PR TITLE
Hent aktive tp ordninger for person

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/model/domain/AktivTpOrdningDto.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/model/domain/AktivTpOrdningDto.kt
@@ -1,0 +1,7 @@
+package no.nav.tjenestepensjon.simulering.model.domain
+
+data class AktivTpOrdningDto(
+    val navn: String,
+    val tpNr: String,
+    val orgNr: String
+)

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/CommonDefaults.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/CommonDefaults.kt
@@ -8,6 +8,8 @@ import java.time.LocalDate
 
 const val defaultFNRString = "01010101010"
 val defaultFNR = FNR(defaultFNRString)
+const val fnrUtenMedlemskap = "01027701010"
+const val fnrMedEttMedlemskapITPOrdning = "01037701010"
 
 const val defaultTpid = "4321"
 const val defaultTssid = "1234"

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/SimuleringAFPEndpointTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/SimuleringAFPEndpointTest.kt
@@ -1,0 +1,99 @@
+package no.nav.tjenestepensjon.simulering.rest
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import no.nav.tjenestepensjon.simulering.defaultFNRString
+import no.nav.tjenestepensjon.simulering.model.domain.pen.AfpOffentligLivsvarigYtelseMedDelingstall
+import no.nav.tjenestepensjon.simulering.model.domain.pen.Alder
+import no.nav.tjenestepensjon.simulering.model.domain.pen.SimulerAFPOffentligLivsvarigResponse
+import no.nav.tjenestepensjon.simulering.service.AADClient
+import no.nav.tjenestepensjon.simulering.testHelper.anyNonNull
+import no.nav.tjenestepensjon.simulering.v2.models.defaultAktiveOrdningerJson
+import no.nav.tjenestepensjon.simulering.v2.models.defaultSimulerBeregningAFPOffentligJson
+import no.nav.tjenestepensjon.simulering.v3.afp.AFPOffentligLivsvarigSimuleringService
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.LocalDate
+
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest
+class SimuleringAFPEndpointTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var aadClient: AADClient
+
+    //    @MockBean
+//    private lateinit var tpClient: TpClient
+    @MockBean
+    private lateinit var aFPOffentligLivsvarigSimuleringService: AFPOffentligLivsvarigSimuleringService
+
+    private var wireMockServer = WireMockServer().apply {
+        start()
+        stubFor(get("/api/tjenestepensjon/aktiveOrdninger").willReturn(okJson(defaultAktiveOrdningerJson)))
+//        stubFor(post(""))
+    }
+
+    @AfterAll
+    fun afterAll() {
+        wireMockServer.stop()
+    }
+
+    @Test
+    @WithMockUser
+    fun simulerAfpOffentligLivsvarig() {
+        Mockito.`when`(aadClient.getToken("api://bogus")).thenReturn("")
+        Mockito.`when`(aFPOffentligLivsvarigSimuleringService.simuler(anyNonNull()))
+            .thenReturn(
+                listOf(AfpOffentligLivsvarigYtelseMedDelingstall(
+                    pensjonsbeholdning = 250000,
+                    afpYtelsePerAar = 50000.1,
+                    delingstall = 18.13,
+                    gjelderFraOgMed = LocalDate.of(2027, 1, 1),
+                    gjelderFraOgMedAlder = Alder(64, 1)))
+            )
+
+        mockMvc.post("/simulering/afp-offentlig-livsvarig") {
+            content = defaultSimulerBeregningAFPOffentligJson
+            contentType = MediaType.APPLICATION_JSON
+        }
+            .andExpect {
+                status { isOk() }
+                content {
+                    content {
+                        """
+                    {
+                        "fnr": "$defaultFNRString"
+                        "ytelser": [
+                            {
+                                "pensjonsbeholdning": 250000,
+                                "afpYtelsePerAar": 50000.1,
+                                "delingstall": 18.13,
+                                "gjelderFraOgMed": "2027-01-01",
+                                "gjelderFraOgMedAlder": {
+                                    "ar": 64,
+                                    "maaneder": 1
+                                }
+                            }
+                        ],
+                        "tpLeverandoerer": "SPK,KLP"
+                    }
+                    """.trimIndent()
+                    }
+                }
+            }
+    }
+
+}

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/SimuleringAFPEndpointTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/SimuleringAFPEndpointTest.kt
@@ -11,7 +11,7 @@ import no.nav.tjenestepensjon.simulering.service.AADClient
 import no.nav.tjenestepensjon.simulering.testHelper.anyNonNull
 import no.nav.tjenestepensjon.simulering.v2.models.defaultAktiveOrdningerJson
 import no.nav.tjenestepensjon.simulering.v2.models.defaultSimulerBeregningAFPOffentligJson
-import no.nav.tjenestepensjon.simulering.v2.models.ettAktivOrdningJson
+import no.nav.tjenestepensjon.simulering.v2.models.enAktivOrdningJson
 import no.nav.tjenestepensjon.simulering.v2.models.simulerBeregningAFPOffentligUtenMedlemskapITPOrdningJson
 import no.nav.tjenestepensjon.simulering.v3.afp.AFPOffentligLivsvarigSimuleringService
 import org.junit.jupiter.api.AfterAll
@@ -39,12 +39,12 @@ class SimuleringAFPEndpointTest {
     private lateinit var aadClient: AADClient
 
     @MockBean
-    private lateinit var aFPOffentligLivsvarigSimuleringService: AFPOffentligLivsvarigSimuleringService
+    private lateinit var afpOffentligLivsvarigSimuleringService: AFPOffentligLivsvarigSimuleringService
 
     private var wireMockServer = WireMockServer().apply {
         start()
         stubFor(get("/api/tjenestepensjon/aktiveOrdninger").withHeader("fnr", equalTo(defaultFNRString)).willReturn(okJson(defaultAktiveOrdningerJson)))
-        stubFor(get("/api/tjenestepensjon/aktiveOrdninger").withHeader("fnr", equalTo(fnrMedEttMedlemskapITPOrdning)).willReturn(okJson(ettAktivOrdningJson)))
+        stubFor(get("/api/tjenestepensjon/aktiveOrdninger").withHeader("fnr", equalTo(fnrMedEttMedlemskapITPOrdning)).willReturn(okJson(enAktivOrdningJson)))
         stubFor(get("/api/tjenestepensjon/aktiveOrdninger").withHeader("fnr", equalTo(fnrUtenMedlemskap)).willReturn(okJson("[]")))
     }
 
@@ -57,7 +57,7 @@ class SimuleringAFPEndpointTest {
     @WithMockUser
     fun `simuler AFP Offentlig for bruker med to aktive medlemskap`() {
         Mockito.`when`(aadClient.getToken("api://bogus")).thenReturn("")
-        Mockito.`when`(aFPOffentligLivsvarigSimuleringService.simuler(anyNonNull()))
+        Mockito.`when`(afpOffentligLivsvarigSimuleringService.simuler(anyNonNull()))
             .thenReturn(
                 listOf(
                     AfpOffentligLivsvarigYtelseMedDelingstall(
@@ -105,7 +105,7 @@ class SimuleringAFPEndpointTest {
     @WithMockUser
     fun `simuler AFP Offentlig for bruker med et medlemskap`() {
         Mockito.`when`(aadClient.getToken("api://bogus")).thenReturn("")
-        Mockito.`when`(aFPOffentligLivsvarigSimuleringService.simuler(anyNonNull()))
+        Mockito.`when`(afpOffentligLivsvarigSimuleringService.simuler(anyNonNull()))
             .thenReturn(
                 listOf(
                     AfpOffentligLivsvarigYtelseMedDelingstall(

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/models/DefaultObjects.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/models/DefaultObjects.kt
@@ -119,3 +119,20 @@ const val defaultSimuleringsperiodeJson =
 
 const val defaultSimulerOffentligTjenestepensjonRequestJson =
     """{"fnr":"$defaultFNRString","fodselsdato":"19010101","sisteTpnr":"$defaultTpid","sprak":"bogus","simulertAFPOffentlig":$defaultSimulertAFPOffentligJson,"simulertAFPPrivat":$defaultSimulertAFPPrivatJson,"sivilstandkode":"GIFT","inntektListe":[$defaultInntektJson],"pensjonsbeholdningsperiodeListe":[$defaultPensjonsbeholdningsperiodeJson],"simuleringsperiodeListe":[$defaultSimuleringsperiodeJson],"simuleringsdataListe":[$defaultSimuleringsDataJson],"tpForholdListe":[$defaultTpForholdJson]}"""
+const val defaultAktiveOrdningerJson =
+    """[{"navn": "SPK", "tpNr": "$defaultTpid", "orgNr": "" }, {"navn": "KLP", "tpNr": "${defaultTpid+1}", "orgNr": "" }]"""
+const val defaultSimulerBeregningAFPOffentligJson =
+    """{"fnr": "$defaultFNRString",
+        "fodselsdato": "1964-02-01",
+          "fremtidigeInntekter": [
+            {
+             "belop": 500000,
+             "fraOgMed": "2024-01-01"
+            },
+            {
+              "belop": 550000,
+              "fraOgMed": "2025-01-01"
+            }
+          ],
+          "fom": "2026-01-01"
+        }"""

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/models/DefaultObjects.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/models/DefaultObjects.kt
@@ -121,6 +121,8 @@ const val defaultSimulerOffentligTjenestepensjonRequestJson =
     """{"fnr":"$defaultFNRString","fodselsdato":"19010101","sisteTpnr":"$defaultTpid","sprak":"bogus","simulertAFPOffentlig":$defaultSimulertAFPOffentligJson,"simulertAFPPrivat":$defaultSimulertAFPPrivatJson,"sivilstandkode":"GIFT","inntektListe":[$defaultInntektJson],"pensjonsbeholdningsperiodeListe":[$defaultPensjonsbeholdningsperiodeJson],"simuleringsperiodeListe":[$defaultSimuleringsperiodeJson],"simuleringsdataListe":[$defaultSimuleringsDataJson],"tpForholdListe":[$defaultTpForholdJson]}"""
 const val defaultAktiveOrdningerJson =
     """[{"navn": "SPK", "tpNr": "$defaultTpid", "orgNr": "" }, {"navn": "KLP", "tpNr": "${defaultTpid+1}", "orgNr": "" }]"""
+const val ettAktivOrdningJson =
+    """[{"navn": "SPK", "tpNr": "$defaultTpid", "orgNr": "" }]"""
 const val defaultSimulerBeregningAFPOffentligJson =
     """{"fnr": "$defaultFNRString",
         "fodselsdato": "1964-02-01",
@@ -135,4 +137,19 @@ const val defaultSimulerBeregningAFPOffentligJson =
             }
           ],
           "fom": "2026-01-01"
+        }"""
+const val simulerBeregningAFPOffentligUtenMedlemskapITPOrdningJson =
+    """{"fnr": "$fnrUtenMedlemskap",
+        "fodselsdato": "1977-02-01",
+          "fremtidigeInntekter": [
+            {
+             "belop": 500000,
+             "fraOgMed": "2038-01-01"
+            },
+            {
+              "belop": 550000,
+              "fraOgMed": "2039-01-01"
+            }
+          ],
+          "fom": "2040-01-01"
         }"""

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/models/DefaultObjects.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/models/DefaultObjects.kt
@@ -121,7 +121,7 @@ const val defaultSimulerOffentligTjenestepensjonRequestJson =
     """{"fnr":"$defaultFNRString","fodselsdato":"19010101","sisteTpnr":"$defaultTpid","sprak":"bogus","simulertAFPOffentlig":$defaultSimulertAFPOffentligJson,"simulertAFPPrivat":$defaultSimulertAFPPrivatJson,"sivilstandkode":"GIFT","inntektListe":[$defaultInntektJson],"pensjonsbeholdningsperiodeListe":[$defaultPensjonsbeholdningsperiodeJson],"simuleringsperiodeListe":[$defaultSimuleringsperiodeJson],"simuleringsdataListe":[$defaultSimuleringsDataJson],"tpForholdListe":[$defaultTpForholdJson]}"""
 const val defaultAktiveOrdningerJson =
     """[{"navn": "SPK", "tpNr": "$defaultTpid", "orgNr": "" }, {"navn": "KLP", "tpNr": "${defaultTpid+1}", "orgNr": "" }]"""
-const val ettAktivOrdningJson =
+const val enAktivOrdningJson =
     """[{"navn": "SPK", "tpNr": "$defaultTpid", "orgNr": "" }]"""
 const val defaultSimulerBeregningAFPOffentligJson =
     """{"fnr": "$defaultFNRString",


### PR DESCRIPTION
Bruker kan være medlem hos flere TP-ordninger. Jeg valgte å vise dem alle sammen og ikke finne ut hvem av de som skal ta ansvar for beregning og vilkårsprøving av AFP Offentlig for brukeren. 