### PR TITLE
oppdater forholdslist dto fra tp

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/model/domain/ForholdWrapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/model/domain/ForholdWrapper.kt
@@ -1,3 +1,3 @@
 package no.nav.tjenestepensjon.simulering.model.domain
 
-data class ForholdWrapper(val forholdDtoList: List<Forhold>)
+data class ForholdWrapper(val forholdModelList: List<Forhold>)

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/TpClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/TpClient.kt
@@ -6,7 +6,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tjenestepensjon.simulering.config.CacheConfig.Companion.TP_ORDNING_LEVERANDOR_CACHE
 import no.nav.tjenestepensjon.simulering.config.CacheConfig.Companion.TP_ORDNING_PERSON_CACHE
 import no.nav.tjenestepensjon.simulering.config.CacheConfig.Companion.TP_ORDNING_TSSID_CACHE
-import no.nav.tjenestepensjon.simulering.exceptions.LeveradoerNotFoundException
 import no.nav.tjenestepensjon.simulering.exceptions.NoTpOrdningerFoundException
 import no.nav.tjenestepensjon.simulering.model.domain.AktivTpOrdningDto
 import no.nav.tjenestepensjon.simulering.model.domain.FNR
@@ -46,7 +45,7 @@ class TpClient(
                     200 -> clientResponse.bodyToMono<String>().flatMapIterable {
                         try {
                             if (it.isBlank() || it == "{}") emptyList()
-                            else jsonMapper.readValue<HateoasWrapper>(it).embedded.forholdDtoList
+                            else jsonMapper.readValue<HateoasWrapper>(it).embedded.forholdModelList
                         } catch (t: Throwable) {
                             log.error(t) { "Failed to parse response from TP, with body: $it" }
                             throw t

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/CommonDefaults.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/CommonDefaults.kt
@@ -13,7 +13,7 @@ const val fnrMedEttMedlemskapITPOrdning = "01037701010"
 
 const val defaultTpid = "4321"
 const val defaultTssid = "1234"
-const val defaultForhold = """{"_embedded": {"forholdDtoList":[{"ytelser":"[]","ordning":"$defaultTpid"}]}}"""
+const val defaultForhold = """{"_embedded": {"forholdModelList":[{"ytelser":"[]","ordning":"$defaultTpid"}]}}"""
 
 const val defaultTjenestepensjonUrl = "/api/tjenestepensjon/forhold"
 const val defaultLeveradorUrl = "/api/tpconfig/tpleverandoer/$defaultTpid"

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/service/TpClientTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/service/TpClientTest.kt
@@ -59,7 +59,7 @@ class TpClientTest {
     @Test
     fun `findForhold uten forhold`() {
         wireMockServer.stubFor(
-            defaultTjenestepensjonRequest.willReturn(okJson("""{"_embedded":{"forholdDtoList":[]}}"""))
+            defaultTjenestepensjonRequest.willReturn(okJson("""{"_embedded":{"forholdModelList":[]}}"""))
         )
 
         assertThrows<NoTpOrdningerFoundException> { tpClient.findForhold(defaultFNR) }


### PR DESCRIPTION
Fra logg:
`> at [Source: (String)"{"_embedded":{"forholdModelList":[{"ordning":"3010","ytelser":[],"createdBy":"PATCH 393","updatedBy":"PATCH 393","kilde":"PP01","datoSistOpptjening":null,"_links":{"ordning":{"href":"https://tp.nais.adeo.no/api/ordninger/3010"},"delete":{"href":"https://tp.nais.adeo.no/api/tjenestepensjon/forhold/3010"},"addYtelse":{"href":"https://tp.nais.adeo.no/api/tjenestepensjon/forhold/3010/ytelse"}}}]}}"; line: 1, column: 395] (through reference chain: no.nav.tjenestepensjon.simulering.model.domain.HateoasWrapper["_embedded"]->no.nav.tjenestepensjon.simulering.model.domain.ForholdWrapper["forholdDtoList"])`