### PR TITLE
Specify CPU and memory resources

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -7,6 +7,12 @@ metadata:
     team: pensjonskalkulator
 spec:
   image: {{ image }}
+  resources:
+    limits:
+      memory: 916Mi
+    requests:
+      cpu: 50m
+      memory: 458Mi
   port: 8080
   webproxy: true
   ingresses:

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -7,6 +7,12 @@ metadata:
     team: pensjonskalkulator
 spec:
   image: {{ image }}
+  resources:
+    limits:
+      memory: 1088Mi
+    requests:
+      cpu: 100m
+      memory: 544Mi
   port: 8080
   webproxy: true
   ingresses:


### PR DESCRIPTION
Spesifiserer ressurser basert på [Utilization i dev](https://console.nav.cloud.nais.io/team/pensjonskalkulator/dev-fss/app/tjenestepensjon-simulering/utilization?from=2024-03-30&to=2024-08-06) og [prod](https://console.nav.cloud.nais.io/team/pensjonskalkulator/prod-fss/app/tjenestepensjon-simulering/utilization?from=2024-03-30&to=2024-08-06).

Uten ressurs-spesifisering (dvs. med [NAIS-defaults](https://docs.nais.io/workloads/application/reference/application-spec/#resources)) bruker appen normalt ca. 160 % av `requests.memory` i dev, og 190 % i prod. NAIS-default er 256Mi (dvs. 268,44MB) per pod.

Endrer slik at appen normalt bruker ca. 90 % av `requests.memory` (256Mi x 161 / 90 = 458Mi i dev).

`limits.memory` settes (som før) til det dobbelte av `requests.memory`.

`requests.cpu` settes i prod til halvparten av NAIS-default (default er 200m), og i dev til 1/4 av NAIS-default (kunne sikkert settes enda lavere, når man ser på _Utilization_, men velger å endre "forsiktig").