### PR TITLE
PEK-519 deploy tjenestepensjon-simulering til dev-gcp

### DIFF
--- a/.github/workflows/manual_deploy_dev.yaml
+++ b/.github/workflows/manual_deploy_dev.yaml
@@ -59,3 +59,20 @@ jobs:
           CLUSTER: dev-fss
           RESOURCE: .nais/nais-dev.yaml
           IMAGE: ${{ needs.build.outputs.image }}
+
+  deploy_dev-gcp:
+    name: Deploy to dev-gcp
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/nais-dev-gcp.yaml
+          IMAGE: ${{ needs.build.outputs.image }}

--- a/.nais/nais-dev-gcp.yaml
+++ b/.nais/nais-dev-gcp.yaml
@@ -14,22 +14,26 @@ spec:
       cpu: 50m
       memory: 458Mi
   port: 8080
-  webproxy: true
   ingresses:
-    - https://tjenestepensjon-simulering.intern.dev.nav.no
+    - https://tjenestepensjon-simulering-gcp.intern.dev.nav.no
   accessPolicy:
     inbound:
       rules:
         - application: pensjon-pen-q0
           namespace: pensjon-q0
+          cluster: dev-fss
         - application: pensjon-pen-q1
           namespace: pensjon-q1
+          cluster: dev-fss
         - application: pensjon-pen-q2
           namespace: pensjon-q2
+          cluster: dev-fss
         - application: pensjon-pen-q5
           namespace: pensjon-q5
+          cluster: dev-fss
         - application: pensjon-testdata-server-q2
           namespace: pensjontestdata
+          cluster: dev-fss
         - application: pensjonskalkulator-backend
           namespace: pensjonskalkulator
           cluster: dev-gcp
@@ -40,10 +44,16 @@ spec:
           cluster: dev-fss
         - application: pensjon-opptjening-afp-api
           namespace: pensjonopptjening
-          cluster: dev-gcp
         - application: pensjon-pen-q2
           namespace: pensjon-q2
           cluster: dev-fss
+        - application: pensjon-selvbetjening-fss-gateway
+          namespace: pensjonselvbetjening
+          cluster: dev-fss
+      external:
+        - host: pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
+        - host: pensjon-pen-q2.dev-fss-pub.nais.io
+        - host: tp-api-q2.dev-fss-pub.nais.io
   azure:
     application:
       enabled: true
@@ -64,23 +74,14 @@ spec:
     initialDelay: 30
     failureThreshold: 30
     periodSeconds: 5
-  vault:
-    enabled: true
-    paths:
-      - kvPath: /kv/preprod/fss/tjenestepensjon-simulering/pensjonskalkulator
-        mountPath: /var/run/secrets/nais.io/vault
   replicas:
     min: 2
     max: 2
   env:
     - name: SPRING_PROFILES_ACTIVE
-      value: preprod
-    - name: provider_uri
-      value: https://pep-gw-q1.oera-q.local:9443/ekstern-pensjon-tjeneste-tjenestepensjonSimuleringWeb/sca/TjenestepensjonSimuleringWSEXP
-    - name: sts_url
-      value: https://security-token-service.nais.preprod.local
+      value: dev-gcp
     - name: tp_url
-      value: https://tp-q2.dev.intern.nav.no
+      value: https://tp-api-q2.dev-fss-pub.nais.io
     - name: tp_scope
       value: api://dev-fss.pensjonsamhandling.tp-q2/.default
     - name: afp_beholdning_url
@@ -88,7 +89,7 @@ spec:
     - name: afp_beholdning_scope
       value: api://dev-gcp.pensjonopptjening.pensjon-opptjening-afp-api/.default
     - name: pen_url
-      value: https://pensjon-pen-q2.nais.preprod.local/pen/springapi
+      value: https://pensjon-pen-q2.dev-fss-pub.nais.io/pen/springapi
     - name: pen_scope
       value: api://dev-fss.pensjon-q2.pensjon-pen-q2/.default
     - name: pen-fss-gateway_url

--- a/.nais/nais-dev-gcp.yaml
+++ b/.nais/nais-dev-gcp.yaml
@@ -92,9 +92,9 @@ spec:
       value: https://pensjon-pen-q2.dev-fss-pub.nais.io/pen/springapi
     - name: pen_scope
       value: api://dev-fss.pensjon-q2.pensjon-pen-q2/.default
-    - name: pen-fss-gateway_url
+    - name: pen_fss_gateway_url
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
-    - name: pen-fss-gateway_scope
+    - name: pen_fss_gateway_scope
       value: api://dev-fss.pensjonselvbetjening.pensjon-selvbetjening-fss-gateway/.default
   prometheus:
     enabled: true

--- a/.nais/nais-dev-gcp.yaml
+++ b/.nais/nais-dev-gcp.yaml
@@ -85,7 +85,7 @@ spec:
     - name: tp_scope
       value: api://dev-fss.pensjonsamhandling.tp-q2/.default
     - name: afp_beholdning_url
-      value: https://pensjon-opptjening-afp-api.intern.dev.nav.no
+      value: https://pensjon-opptjening-afp-api.pensjonopptjening
     - name: afp_beholdning_scope
       value: api://dev-gcp.pensjonopptjening.pensjon-opptjening-afp-api/.default
     - name: pen_url

--- a/.nais/nais-dev-gcp.yaml
+++ b/.nais/nais-dev-gcp.yaml
@@ -85,7 +85,7 @@ spec:
     - name: tp_scope
       value: api://dev-fss.pensjonsamhandling.tp-q2/.default
     - name: afp_beholdning_url
-      value: https://pensjon-opptjening-afp-api.pensjonopptjening
+      value: http://pensjon-opptjening-afp-api.pensjonopptjening
     - name: afp_beholdning_scope
       value: api://dev-gcp.pensjonopptjening.pensjon-opptjening-afp-api/.default
     - name: pen_url

--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -91,9 +91,9 @@ spec:
       value: https://pensjon-pen-q2.nais.preprod.local/pen/springapi
     - name: pen_scope
       value: api://dev-fss.pensjon-q2.pensjon-pen-q2/.default
-    - name: pen-fss-gateway_url
+    - name: pen_fss_gateway_url
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
-    - name: pen-fss-gateway_scope
+    - name: pen_fss_gateway_scope
       value: api://dev-fss.pensjonselvbetjening.pensjon-selvbetjening-fss-gateway/.default
   prometheus:
     enabled: true

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -83,6 +83,10 @@ spec:
       value: https://pensjon-pen.nais.adeo.no/pen/springapi
     - name: pen_scope
       value: api://prod-fss.pensjondeployer.pensjon-pen/.default
+    - name: pen-fss-gateway_url
+      value: https://pensjon-selvbetjening-fss-gateway.prod-fss-pub.nais.io
+    - name: pen-fss-gateway_scope
+      value: api://prod-fss.pensjonselvbetjening.pensjon-selvbetjening-fss-gateway/.default
   prometheus:
     enabled: true
     path: actuator/prometheus

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -83,9 +83,9 @@ spec:
       value: https://pensjon-pen.nais.adeo.no/pen/springapi
     - name: pen_scope
       value: api://prod-fss.pensjondeployer.pensjon-pen/.default
-    - name: pen-fss-gateway_url
+    - name: pen_fss_gateway_url
       value: https://pensjon-selvbetjening-fss-gateway.prod-fss-pub.nais.io
-    - name: pen-fss-gateway_scope
+    - name: pen_fss_gateway_scope
       value: api://prod-fss.pensjonselvbetjening.pensjon-selvbetjening-fss-gateway/.default
   prometheus:
     enabled: true

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
@@ -76,8 +76,8 @@ class WebClientConfig {
 
     @Bean
     fun soapGatewayAuthWebClient(
-        @Value("\${pen-fss-gateway.url}") url: String,
-        @Value("\${pen-fss-gateway.scope}") scope: String,
+        @Value("\${pen.fss.gateway.url}") url: String,
+        @Value("\${pen.fss.gateway.scope}") scope: String,
         httpClient: HttpClient,
         adClient: AADClient,
     ): WebClient {

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/TokenService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/TokenService.kt
@@ -4,5 +4,5 @@ import no.nav.tjenestepensjon.simulering.domain.Token
 
 interface TokenService {
     val oidcAccessToken: Token?
-    val samlAccessToken: Token?
+    val samlAccessToken: Token
 }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v1/consumer/GatewayTokenClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v1/consumer/GatewayTokenClient.kt
@@ -1,0 +1,28 @@
+package no.nav.tjenestepensjon.simulering.v1.consumer
+
+import no.nav.tjenestepensjon.simulering.domain.Token
+import no.nav.tjenestepensjon.simulering.domain.TokenImpl
+import no.nav.tjenestepensjon.simulering.service.TokenService
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+@Profile(value = ["prod-gcp", "dev-gcp"])
+@Service
+class GatewayTokenClient(private val soapGatewayAuthWebClient: WebClient) : TokenService {
+
+    override val oidcAccessToken: Token?
+        get() = null //not supported
+    override var samlAccessToken: Token = TokenImpl("", expiresIn = -1)
+        get() = if (field.isExpired) hentSamlToken().also { field = it }
+        else field
+
+    private fun hentSamlToken(): Token {
+        return soapGatewayAuthWebClient
+            .post()
+            .uri("/rest/v1/sts/token/exchange")
+            .retrieve()
+            .bodyToMono(TokenImpl::class.java)
+            .block() ?: throw RuntimeException("Failed to fetch SAML token from fss-gateway")
+    }
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v1/consumer/TokenClientOld.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v1/consumer/TokenClientOld.kt
@@ -7,12 +7,14 @@ import no.nav.tjenestepensjon.simulering.service.TokenService
 import no.nav.tjenestepensjon.simulering.v1.consumer.TokenClientOld.TokenType.OIDC
 import no.nav.tjenestepensjon.simulering.v1.consumer.TokenClientOld.TokenType.SAML
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import java.net.URI
 
+@Profile(value = ["prod", "preprod"]) //TODO fjern, når appen flyttes til gcp
 @Service
 class TokenClientOld(private val webClient: WebClient) : TokenService {
     private val log = KotlinLogging.logger {}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v1/soap/SoapClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v1/soap/SoapClient.kt
@@ -3,9 +3,9 @@ package no.nav.tjenestepensjon.simulering.v1.soap
 import no.nav.tjenestepensjon.simulering.model.domain.FNR
 import no.nav.tjenestepensjon.simulering.model.domain.TPOrdningIdDto
 import no.nav.tjenestepensjon.simulering.model.domain.TpLeverandor
+import no.nav.tjenestepensjon.simulering.service.TokenService
 import no.nav.tjenestepensjon.simulering.v1.TPOrdningStillingsprosentMap
 import no.nav.tjenestepensjon.simulering.v1.Tjenestepensjonsimulering
-import no.nav.tjenestepensjon.simulering.v1.consumer.TokenClientOld
 import no.nav.tjenestepensjon.simulering.v1.models.request.HentStillingsprosentListeRequest
 import no.nav.tjenestepensjon.simulering.v1.models.request.SimulerOffentligTjenestepensjonRequest
 import no.nav.tjenestepensjon.simulering.v1.models.request.SimulerPensjonRequestV1
@@ -22,7 +22,7 @@ import org.springframework.ws.client.core.support.WebServiceGatewaySupport
 @Service
 @Controller
 class SoapClient(
-    webServiceTemplate: WebServiceTemplate, private val tokenClientOld: TokenClientOld
+    webServiceTemplate: WebServiceTemplate, private val tokenService: TokenService
 ) : WebServiceGatewaySupport(), Tjenestepensjonsimulering {
 
     init {
@@ -44,7 +44,7 @@ class SoapClient(
         HentStillingsprosentListeRequest(fnr, tpOrdning).let(SOAPAdapter::marshal), SOAPCallback(
             hentStillingsprosentUrl,
             tpLeverandor.stillingsprosentUrl,
-            tokenClientOld.samlAccessToken.accessToken,
+            tokenService.samlAccessToken.accessToken,
             samlConfig
         )
     ).let {
@@ -74,7 +74,7 @@ class SoapClient(
         }.let(SOAPAdapter::marshal), SOAPCallback(
             simulerOffentlingTjenestepensjonUrl,
             tpLeverandor.simuleringUrl,
-            tokenClientOld.samlAccessToken.accessToken,
+            tokenService.samlAccessToken.accessToken,
             samlConfig
         )
     ).let {

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -1,0 +1,37 @@
+logging.level:
+  no.nav.tjenestepensjon: DEBUG
+  org.springframework:
+    security.oauth2: DEBUG
+    ws:
+      web: DEBUG
+      client.MessageTracing: DEBUG
+  com.microsoft.aad: DEBUG
+
+simulering:
+  security:
+    issuers: ${azure.openid-config-issuer},https://security-token-service.nais.preprod.local,https://security-token-service-t4.nais.preprod.local,https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/
+klp:
+  name: KLP
+  implementation: REST
+  simuleringUrl: https://partner-gw-test2.klp.no/api/pensjonsimulering
+  stillingsprosentUrl: https://partner-gw-stage.klp.no/navs-ws-gateway/inbound/simuleretjenestepensjon
+spk:
+  name: SPK
+  implementation: REST
+  simuleringUrl: https://api.preprod.spk.no/medlem/pensjon/prognose/v1
+  stillingsprosentUrl: https://partner-gw-test.spk.no/nav/SimulereTjenestepensjon
+storebrand:
+  name: STOREBRAND
+  implementation: SOAP
+  simuleringUrl: https://b2b-t.storebrand.no/nav/SimulerTP
+  stillingsprosentUrl: https://b2b-t.storebrand.no/nav/SimulerTP
+gabler:
+  name: GABLER
+  implementation: SOAP
+  simuleringUrl: https://elsam.gabler.no/elsam.svc
+  stillingsprosentUrl: https://elsam.gabler.no/elsam.svc
+opf:
+  name: OPF
+  implementation: SOAP
+  simuleringUrl: https://partner-gw.opf.no/Elsam.svc
+  stillingsprosentUrl: https://partner-gw.opf.no/Elsam.svc

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,6 @@ afp:
 pen:
     url: http://localhost:8080
     scope: api://bogus
+pen-fss-gateway:
+    url: http://localhost:8080
+    scope: api://bogus

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,8 +47,9 @@ afp:
     url: http://localhost:8080
     scope: api://bogus
 pen:
-    url: http://localhost:8080
-    scope: api://bogus
-pen-fss-gateway:
-    url: http://localhost:8080
-    scope: api://bogus
+  url: http://localhost:8080
+  scope: api://bogus
+  fss:
+    gateway:
+      url: http://localhost:8080
+      scope: api://bogus

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v1/rest/SimuleringEndpointSecurityTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v1/rest/SimuleringEndpointSecurityTest.kt
@@ -21,11 +21,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestInstance(PER_CLASS)

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/rest/SimuleringEndpointSecurityTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/rest/SimuleringEndpointSecurityTest.kt
@@ -21,10 +21,12 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestInstance(PER_CLASS)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -56,9 +56,10 @@ afp:
 pen:
   url: http://localhost:8080
   scope: api://bogus
-pen-fss-gateway:
-  url: http://localhost:8080
-  scope: api://bogus
+  fss:
+    gateway:
+      url: http://localhost:8080
+      scope: api://bogus
 spring:
   profiles:
     active: dev-gcp,test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -56,3 +56,9 @@ afp:
 pen:
   url: http://localhost:8080
   scope: api://bogus
+pen-fss-gateway:
+  url: http://localhost:8080
+  scope: api://bogus
+spring:
+  profiles:
+    active: dev-gcp,test


### PR DESCRIPTION
* Legg til NAIS-konfigurasjon for `dev-gcp`
* Legg til en ny implementasjon av `TokenService` som henter token via `pensjon-selvbetjening-fss-gateway` for `dev-gcp`
* Set Spring profiles der det trengs avhengig av miljø
* Fjern ubrukte felter fra `TokenClient` 
* Oppdatere testkonfigurasjon