### PR TITLE
PEK-715 sett sluttAlder, send maanedsbeloep istedenfor

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/response/SimulerTjenestepensjonResponseDto.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/response/SimulerTjenestepensjonResponseDto.kt
@@ -1,5 +1,7 @@
 package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.response
 
+import no.nav.tjenestepensjon.simulering.model.domain.pen.Alder
+
 data class SimulerTjenestepensjonResponseDto(
     val simuleringsResultatStatus: SimuleringsResultatStatusDto,
     val simuleringsResultat: SimuleringsResultatDto? = null,
@@ -25,11 +27,12 @@ enum class ResultatTypeDto {
 
 data class SimuleringsResultatDto(
     val tpLeverandoer: String,
-    val utbetalingsperioder: List<UtbetalingPerAar>,
+    val utbetalingsperioder: List<UtbetalingPerAlder>,
     val betingetTjenestepensjonErInkludert: Boolean,
 )
 
-data class UtbetalingPerAar(
-    val aar: Int,
-    val beloep: Int,
+data class UtbetalingPerAlder(
+    val startAlder: Alder,
+    val sluttAlder: Alder?,
+    val maanedligBeloep: Int,
 )

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025ControllerTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025ControllerTest.kt
@@ -6,7 +6,6 @@ import no.nav.tjenestepensjon.simulering.service.AADClient
 import no.nav.tjenestepensjon.simulering.v2.models.defaultSimulerTjenestepensjonHosSPKJson
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Maanedsutbetaling
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.Tjenestepensjon2025AggregatorTest.Companion.MAANEDER_I_AAR
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.BrukerErIkkeMedlemException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpOrdningStoettesIkkeException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpregisteretException
@@ -79,10 +78,6 @@ class TjenestepensjonSimuleringV2025ControllerTest {
 
         `when`(service.simuler(any())).thenReturn(listOf("Statens pensjonskasse") to Result.success(mockRespons))
         `when`(aadClient.getToken("api://bogus")).thenReturn("")
-        val aarsBeloepVed63 = perioder[0].maanedsBeloep * (perioder[1].fraOgMedAlder.maaneder) +
-                perioder[1].maanedsBeloep * (perioder[2].fraOgMedAlder.maaneder - perioder[1].fraOgMedAlder.maaneder) +
-                perioder[2].maanedsBeloep * (MAANEDER_I_AAR - perioder[2].fraOgMedAlder.maaneder)
-
         mockMvc.post("/v2025/tjenestepensjon/v1/simulering") {
             content = defaultSimulerTjenestepensjonHosSPKJson
             contentType = MediaType.APPLICATION_JSON
@@ -101,100 +96,34 @@ class TjenestepensjonSimuleringV2025ControllerTest {
                                 "tpLeverandoer": "${mockRespons.tpLeverandoer}",
                                 "utbetalingsperioder": [
                                     {
-                                        "aar": 62,
-                                        "beloep": 11000
+                                        "startAlder": {
+                                            "aar": 62,
+                                            "maaneder": 1
+                                        },
+                                        "sluttAlder": {
+                                            "aar": 63,
+                                            "maaneder": 3
+                                        },
+                                        "maanedligBeloep": 1000
                                     },
                                     {
-                                        "aar": 63,
-                                        "beloep": $aarsBeloepVed63
+                                        "startAlder": {
+                                            "aar": 63,
+                                            "maaneder": 4
+                                        },
+                                        "sluttAlder": {
+                                            "aar": 63,
+                                            "maaneder": 6
+                                        },
+                                        "maanedligBeloep": 2000
                                     },
                                     {
-                                        "aar": 64,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 65,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 66,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 67,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 68,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 69,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 70,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 71,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 72,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 73,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 74,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 75,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 76,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 77,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 78,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 79,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 80,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 81,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 82,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 83,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 84,
-                                        "beloep": 36000
-                                    },
-                                    {
-                                        "aar": 85,
-                                        "beloep": 36000
+                                        "startAlder": {
+                                            "aar": 63,
+                                            "maaneder": 7
+                                        },
+                                        "sluttAlder": null,
+                                        "maanedligBeloep": 3000
                                     }
                                 ],
                                 "betingetTjenestepensjonErInkludert": true
@@ -276,5 +205,9 @@ class TjenestepensjonSimuleringV2025ControllerTest {
             contentType = MediaType.APPLICATION_JSON
         }
             .andExpect { status { is5xxServerError() } }
+    }
+
+    companion object {
+        const val MAANEDER_I_AAR = 12
     }
 }

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/Tjenestepensjon2025AggregatorTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/Tjenestepensjon2025AggregatorTest.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 class Tjenestepensjon2025AggregatorTest {
 
     @Test
-    fun `aggreger varierende maanedsperioder til aarlige perioder`() {
+    fun `aggreger varierende maanedsperioder inkludert ved aarskifte til perioder med slutt alder`() {
         val simulertTjenestepensjon = SimulertTjenestepensjonMedMaanedsUtbetalinger(
             tpLeverandoer = "tpLeverandoer",
             ordningsListe = listOf(Ordning("3010")),
@@ -22,27 +22,17 @@ class Tjenestepensjon2025AggregatorTest {
                 Maanedsutbetaling(
                     fraOgMedDato = LocalDate.parse("2025-03-01"),
                     maanedsBeloep = 1000,
-                    fraOgMedAlder = Alder(aar = FOERSTE_MULIGE_UTTAKS_AAR, maaneder = 0)
+                    fraOgMedAlder = Alder(aar = 62, maaneder = 6)
                 ),
                 Maanedsutbetaling(
                     fraOgMedDato = LocalDate.parse("2025-09-01"),
                     maanedsBeloep = 2000,
-                    fraOgMedAlder = Alder(aar = FOERSTE_MULIGE_UTTAKS_AAR, maaneder = 6)
-                ),
-                Maanedsutbetaling(
-                    fraOgMedDato = LocalDate.parse("2026-03-01"),
-                    maanedsBeloep = 3000,
                     fraOgMedAlder = Alder(aar = 63, maaneder = 0)
                 ),
                 Maanedsutbetaling(
-                    fraOgMedDato = LocalDate.parse("2030-03-01"),
-                    maanedsBeloep = 4000,
-                    fraOgMedAlder = Alder(aar = 67, maaneder = 0)
-                ),
-                Maanedsutbetaling(
-                    fraOgMedDato = LocalDate.parse("2032-01-01"),
+                    fraOgMedDato = LocalDate.parse("2030-01-01"),
                     maanedsBeloep = 5000,
-                    fraOgMedAlder = Alder(aar = 68, maaneder = 10)
+                    fraOgMedAlder = Alder(aar = 68, maaneder = 4)
                 ),
             ),
             aarsakIngenUtbetaling = emptyList()
@@ -52,61 +42,22 @@ class Tjenestepensjon2025AggregatorTest {
         val result: SimulerTjenestepensjonResponseDto = Tjenestepensjon2025Aggregator.aggregerVellykketRespons(simulertTjenestepensjon, ordninger)
 
         assertEquals(ResultatTypeDto.SUCCESS, result.simuleringsResultatStatus.resultatType)
-
-        val antallAarligeUtbetalinger = SISTE_UTBETALINGSAAR - FOERSTE_MULIGE_UTTAKS_AAR + 1 // inkluderer første uttaksår
-
-        assertEquals(antallAarligeUtbetalinger, result.simuleringsResultat?.utbetalingsperioder?.size)
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder.size, result.simuleringsResultat?.utbetalingsperioder?.size)
         assertEquals(simulertTjenestepensjon.tpLeverandoer, result.simuleringsResultat?.tpLeverandoer)
-        assertEquals(FOERSTE_MULIGE_UTTAKS_AAR, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.aar)
-        assertEquals(1000 * 6 + 2000 * 6, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.beloep)
-        assertEquals(FOERSTE_MULIGE_UTTAKS_AAR + 1, result.simuleringsResultat?.utbetalingsperioder?.get(1)?.aar)
-        assertEquals(3000 * MAANEDER_I_AAR, result.simuleringsResultat?.utbetalingsperioder?.get(1)?.beloep)
-        assertEquals(FOERSTE_MULIGE_UTTAKS_AAR + 2, result.simuleringsResultat?.utbetalingsperioder?.get(2)?.aar)
-        assertEquals(3000 * MAANEDER_I_AAR, result.simuleringsResultat?.utbetalingsperioder?.get(2)?.beloep)
-        assertEquals(FOERSTE_MULIGE_UTTAKS_AAR + 3, result.simuleringsResultat?.utbetalingsperioder?.get(3)?.aar)
-        assertEquals(3000 * MAANEDER_I_AAR, result.simuleringsResultat?.utbetalingsperioder?.get(3)?.beloep)
-        assertEquals(FOERSTE_MULIGE_UTTAKS_AAR + 4, result.simuleringsResultat?.utbetalingsperioder?.get(4)?.aar)
-        assertEquals(3000 * MAANEDER_I_AAR, result.simuleringsResultat?.utbetalingsperioder?.get(4)?.beloep)
-        assertEquals(FOERSTE_MULIGE_UTTAKS_AAR + 5, result.simuleringsResultat?.utbetalingsperioder?.get(5)?.aar)
-        assertEquals(4000 * MAANEDER_I_AAR, result.simuleringsResultat?.utbetalingsperioder?.get(5)?.beloep)
-        assertEquals(FOERSTE_MULIGE_UTTAKS_AAR + 6, result.simuleringsResultat?.utbetalingsperioder?.get(6)?.aar)
-        assertEquals(4000 * 10 + 5000 * 2, result.simuleringsResultat?.utbetalingsperioder?.get(6)?.beloep)
 
-        var aarAlder = FOERSTE_MULIGE_UTTAKS_AAR + 7
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[0].fraOgMedAlder, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.startAlder)
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[1].fraOgMedAlder.aar - 1, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.sluttAlder?.aar)
+        assertEquals(11, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.sluttAlder?.maaneder)
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[0].maanedsBeloep, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.maanedligBeloep)
 
-        for (index in 7 until result.simuleringsResultat!!.utbetalingsperioder.size) {
-            assertEquals(aarAlder, result.simuleringsResultat!!.utbetalingsperioder[index].aar)
-            assertEquals(5000 * 12, result.simuleringsResultat!!.utbetalingsperioder[index].beloep)
-            aarAlder++
-        }
-    }
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[1].fraOgMedAlder, result.simuleringsResultat?.utbetalingsperioder?.get(1)?.startAlder)
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[2].fraOgMedAlder.aar, result.simuleringsResultat?.utbetalingsperioder?.get(1)?.sluttAlder?.aar)
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[2].fraOgMedAlder.maaneder - 1, result.simuleringsResultat?.utbetalingsperioder?.get(1)?.sluttAlder?.maaneder)
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[1].maanedsBeloep, result.simuleringsResultat?.utbetalingsperioder?.get(1)?.maanedligBeloep)
 
-    @Test
-    fun `aggreger en maanedsutbetaling til aarlige perioder`() {
-        val simulertTjenestepensjon = SimulertTjenestepensjonMedMaanedsUtbetalinger(
-            tpLeverandoer = "pensjonskasse",
-            ordningsListe = listOf(Ordning("3010")),
-            utbetalingsperioder = listOf(
-                Maanedsutbetaling(
-                    fraOgMedDato = LocalDate.parse("2026-03-01"),
-                    maanedsBeloep = 1000,
-                    fraOgMedAlder = Alder(aar = 63, maaneder = 3)
-                )))
-        val ordninger = listOf("pensjonskasse")
-
-        val result: SimulerTjenestepensjonResponseDto = Tjenestepensjon2025Aggregator.aggregerVellykketRespons(simulertTjenestepensjon, ordninger)
-
-        assertEquals(ResultatTypeDto.SUCCESS, result.simuleringsResultatStatus.resultatType)
-
-        val antallAarligeUtbetalinger = SISTE_UTBETALINGSAAR - 63 + 1 // inkluderer første uttaksår
-        assertEquals(antallAarligeUtbetalinger, result.simuleringsResultat?.utbetalingsperioder?.size)
-        assertEquals(simulertTjenestepensjon.tpLeverandoer, result.simuleringsResultat?.tpLeverandoer)
-        assertEquals(63, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.aar)
-        assertEquals(1000 * (MAANEDER_I_AAR - 3), result.simuleringsResultat?.utbetalingsperioder?.get(0)?.beloep)
-        for (index in 1 until result.simuleringsResultat!!.utbetalingsperioder.size) {
-            assertEquals(63 + index, result.simuleringsResultat!!.utbetalingsperioder[index].aar)
-            assertEquals(1000 * MAANEDER_I_AAR, result.simuleringsResultat!!.utbetalingsperioder[index].beloep)
-        }
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[2].fraOgMedAlder, result.simuleringsResultat?.utbetalingsperioder?.get(2)?.startAlder)
+        assertNull(result.simuleringsResultat?.utbetalingsperioder?.get(2)?.sluttAlder)
+        assertEquals(simulertTjenestepensjon.utbetalingsperioder[2].maanedsBeloep, result.simuleringsResultat?.utbetalingsperioder?.get(2)?.maanedligBeloep)
     }
 
     @Test
@@ -124,11 +75,5 @@ class Tjenestepensjon2025AggregatorTest {
         assertEquals(ResultatTypeDto.SUCCESS, result.simuleringsResultatStatus.resultatType)
         assertTrue(result.simuleringsResultat!!.utbetalingsperioder.isEmpty())
         assertEquals(simulertTjenestepensjon.tpLeverandoer, result.simuleringsResultat!!.tpLeverandoer)
-    }
-
-    companion object {
-        const val FOERSTE_MULIGE_UTTAKS_AAR = 62
-        const val MAANEDER_I_AAR = 12
-        const val SISTE_UTBETALINGSAAR = 85
     }
 }


### PR DESCRIPTION
Frontend i pensjonskalkulator vil ha så likt som mulig som pensjonsavtaler endepunkt.

Dette innebærer innføring av sluttAlder og slutt på generering av årlige beløp for hver alder