### PR TITLE
Feature/pek 823 ta i bruk sporingslogg

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/Organisasjon.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/Organisasjon.kt
@@ -1,0 +1,8 @@
+package no.nav.tjenestepensjon.simulering.sporingslogg
+
+enum class Organisasjon(val organisasjonsnummer: String, fulltNavn: String, alias: String) {
+    SPK("982583462", "Statens Pensjonskasse", "spk"),
+    KLP("938708606", "Kommunal Landspensjonskasse", "klp"),
+    NAV("889640782", "Nav", "nav"),
+    STB("931936492", "Storebrand", "stb"),
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/SporingDto.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/SporingDto.kt
@@ -1,0 +1,11 @@
+package no.nav.tjenestepensjon.simulering.sporingslogg
+
+data class SporingDto(
+    val person: String,
+    val mottaker: String,
+    val tema: String,
+    val behandlingsGrunnlag: String,
+    val uthentingsTidspunkt: String,
+    var dataForespoersel: String,
+    var leverteData: String = "(no data)"
+)

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/SporingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/SporingDtoMapper.kt
@@ -1,0 +1,18 @@
+package no.nav.tjenestepensjon.simulering.sporingslogg
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
+object SporingDtoMapper {
+    fun toDto(sporingsrapport: Sporingsrapport): SporingDto {
+        return SporingDto(
+            person = sporingsrapport.ident,
+            mottaker = sporingsrapport.organisasjonsnummer,
+            tema = "PEK",
+            behandlingsGrunnlag = "B353",
+            uthentingsTidspunkt = LocalDateTime.now().format(ISO_LOCAL_DATE_TIME),
+            dataForespoersel = sporingsrapport.dataSendtIRequest,
+            leverteData = "(no data)"
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/SporingsloggService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/SporingsloggService.kt
@@ -1,0 +1,56 @@
+package no.nav.tjenestepensjon.simulering.sporingslogg
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tjenestepensjon.simulering.sporingslogg.SporingDtoMapper.toDto
+import org.springframework.core.env.Environment
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.util.retry.Retry
+
+@Service
+class SporingsloggService(val sporingsloggGatewayWebClient: WebClient, val objectMapper: ObjectMapper, private val environment: Environment) {
+    private val log = KotlinLogging.logger {}
+
+    fun loggUtgaaendeRequest(organisasjon: Organisasjon, ident: String, data: Any) {
+        if (environment.activeProfiles.contains("prod-gcp")) {
+            try {
+                val dataSendtIRequest = objectMapper.writeValueAsString(data)
+                rapporter(Sporingsrapport(ident, organisasjon.organisasjonsnummer, dataSendtIRequest))
+            } catch (e: JsonProcessingException) {
+                log.error(e) { "Failed to serialize data to JSON from class: ${data.javaClass}" }
+            } catch (e: Exception) {
+                log.error(e) { "Failed to send sporingsrapport" }
+            }
+        }
+    }
+
+    private fun rapporter(sporingsrapport: Sporingsrapport) {
+        sporingsloggGatewayWebClient.post()
+            .uri("/sporingslogg")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(toDto(sporingsrapport))
+            .retrieve()
+            .toBodilessEntity()
+            .retryWhen(RETRY)
+            .doOnSuccess {
+                log.info { "Successfully sent sporingsrapport" }
+            }
+            .doOnError { e ->
+                when (e) {
+                    is WebClientRequestException -> log.error(e) { "Request to sporingslogg failed at ${e.uri}" }
+                    is WebClientResponseException -> log.error(e) { "Request to sporingslogg failed with status code: ${e.statusCode}" }
+                    else -> log.error(e) { "Request to sporingslogg failed" }
+                }
+            }
+            .subscribe() // Fire-and-forget
+    }
+
+    companion object {
+        private val RETRY = Retry.backoff(3, java.time.Duration.ofSeconds(1))
+    }
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/Sporingsrapport.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/sporingslogg/Sporingsrapport.kt
@@ -1,0 +1,7 @@
+package no.nav.tjenestepensjon.simulering.sporingslogg
+
+data class Sporingsrapport(
+    val ident: String,
+    val organisasjonsnummer: String,
+    val dataSendtIRequest: String
+)

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonClient.kt
@@ -3,6 +3,8 @@ package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tjenestepensjon.simulering.ping.PingResponse
 import no.nav.tjenestepensjon.simulering.ping.Pingable
+import no.nav.tjenestepensjon.simulering.sporingslogg.Organisasjon
+import no.nav.tjenestepensjon.simulering.sporingslogg.SporingsloggService
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjon
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TjenestepensjonSimuleringException
@@ -16,24 +18,29 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.reactive.function.client.bodyToMono
 
 @Service
-class KLPTjenestepensjonClient(private val klpWebClient: WebClient) : TjenestepensjonV2025Client, Pingable {
+class KLPTjenestepensjonClient(
+    private val klpWebClient: WebClient,
+    private val sporingsloggService: SporingsloggService
+) : TjenestepensjonV2025Client, Pingable {
     private val log = KotlinLogging.logger {}
 
     override fun simuler(request: SimulerTjenestepensjonRequestDto): Result<SimulertTjenestepensjon> {
+        val dto = KLPMapper.mapToRequest(request)
+        sporingsloggService.loggUtgaaendeRequest(Organisasjon.KLP, request.pid, dto)
         try {
             val response = klpWebClient
                 .post()
                 .uri(SIMULER_PATH)
-                .bodyValue(KLPMapper.mapToRequest(request))
+                .bodyValue(dto)
                 .retrieve()
                 .bodyToMono<KLPSimulerTjenestepensjonResponse>()
                 .block()
             return response?.let { Result.success(KLPMapper.mapToResponse(it)) } ?: Result.failure(TjenestepensjonSimuleringException("No response body"))
         } catch (e: WebClientResponseException) {
-            val errorMsg = "Failed to simulate tjenestepensjon 2025 hos KLP ${ e.responseBodyAsString}"
+            val errorMsg = "Failed to simulate tjenestepensjon 2025 hos KLP ${e.responseBodyAsString}"
             log.error(e) { errorMsg }
             return Result.failure(TjenestepensjonSimuleringException(errorMsg))
-        } catch (e: WebClientRequestException){
+        } catch (e: WebClientRequestException) {
             log.error(e) { "Failed to send request to simulate tjenestepensjon 2025 hos KLP med url ${e.uri}" }
             return Result.failure(TjenestepensjonSimuleringException("Failed to send request to simulate tjenestepensjon 2025 hos KLP"))
         }

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/SimuleringAFPEndpointTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/SimuleringAFPEndpointTest.kt
@@ -22,7 +22,7 @@ import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
@@ -36,13 +36,13 @@ class SimuleringAFPEndpointTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var aadClient: AADClient
 
-    @MockBean
+    @MockitoBean
     private lateinit var fssGatewayAuthService: FssGatewayAuthService
 
-    @MockBean
+    @MockitoBean
     private lateinit var afpOffentligLivsvarigSimuleringService: AFPOffentligLivsvarigSimuleringService
 
     private var wireMockServer = WireMockServer().apply {

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025ControllerTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025ControllerTest.kt
@@ -18,7 +18,7 @@ import org.mockito.kotlin.any
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
@@ -33,10 +33,10 @@ class TjenestepensjonSimuleringV2025ControllerTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var aadClient: AADClient
 
-    @MockBean
+    @MockitoBean
     private lateinit var service: TjenestepensjonV2025Service
 
     private var wireMockServer = WireMockServer().apply {

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/service/TpClientTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/service/TpClientTest.kt
@@ -19,22 +19,22 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [TpClient::class, WebClientConfig::class, ObjectMapperConfig::class, TestConfig::class])
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TpClientTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var aadClient: AADClient
 
-    @MockBean
+    @MockitoBean
     private lateinit var fssGatewayAuthService: FssGatewayAuthService
 
     @Autowired
     private lateinit var tpClient: TpClient
 
-    @MockBean
+    @MockitoBean
     private lateinit var maskinportenTokenClient: MaskinportenTokenClient
 
     private var wireMockServer = WireMockServer().apply {

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v1/rest/SimuleringEndpointSecurityTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v1/rest/SimuleringEndpointSecurityTest.kt
@@ -20,7 +20,7 @@ import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
@@ -39,16 +39,16 @@ class SimuleringEndpointSecurityTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var aadClient: AADClient
 
-    @MockBean
+    @MockitoBean
     private lateinit var fssGatewayAuthService: FssGatewayAuthService
 
-    @MockBean
+    @MockitoBean
     private lateinit var tokenService: TokenService
 
-    @MockBean
+    @MockitoBean
     private lateinit var soapClient: SoapClient
 
     private var wireMockServer = WireMockServer().apply {

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v1/soap/SoapClientTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v1/soap/SoapClientTest.kt
@@ -6,6 +6,7 @@ import no.nav.tjenestepensjon.simulering.defaultTPOrdningIdDto
 import no.nav.tjenestepensjon.simulering.domain.TokenImpl
 import no.nav.tjenestepensjon.simulering.model.domain.TpLeverandor
 import no.nav.tjenestepensjon.simulering.model.domain.TpLeverandor.EndpointImpl.SOAP
+import no.nav.tjenestepensjon.simulering.sporingslogg.SporingsloggService
 import no.nav.tjenestepensjon.simulering.testHelper.anyNonNull
 import no.nav.tjenestepensjon.simulering.v1.consumer.TokenClientOld
 import no.nav.tjenestepensjon.simulering.v1.models.*
@@ -17,18 +18,21 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.ws.client.core.WebServiceTemplate
 
 
 @SpringBootTest(classes = [TokenClientOld::class, WebServiceTemplate::class, SoapClient::class, SamlConfig::class, ObjectMapperConfig::class])
 internal class SoapClientTest {
 
-    @MockBean
+    @MockitoBean
     lateinit var template: WebServiceTemplate
 
-    @MockBean
+    @MockitoBean
     lateinit var tokenClientOld: TokenClientOld
+
+    @MockitoBean
+    lateinit var sporingsloggService: SporingsloggService
 
     @Autowired
     lateinit var client: SoapClient

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/rest/SimuleringEndpointSecurityTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/rest/SimuleringEndpointSecurityTest.kt
@@ -18,7 +18,7 @@ import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
@@ -34,13 +34,13 @@ class SimuleringEndpointSecurityTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var aadClient: AADClient
 
-    @MockBean
+    @MockitoBean
     private lateinit var soapClient: SoapClient
 
-    @MockBean
+    @MockitoBean
     private lateinit var restClient: RestClient
 
     private var wireMockServer = WireMockServer().apply {

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025ServiceTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025ServiceTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.server.ResponseStatusException
@@ -26,13 +26,13 @@ import kotlin.test.fail
 @SpringBootTest
 class TjenestepensjonV2025ServiceTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var tp: TpClient
 
-    @MockBean
+    @MockitoBean
     private lateinit var spk: SPKTjenestepensjonService
 
-    @MockBean
+    @MockitoBean
     private lateinit var klp: KLPTjenestepensjonService
 
     @Autowired

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonClientTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonClientTest.kt
@@ -20,16 +20,16 @@ import org.junit.jupiter.api.TestInstance
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.LocalDate
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SPKTjenestepensjonClientTest{
 
-    @MockBean
+    @MockitoBean
     private lateinit var aadClient: AADClient
-    @MockBean
+    @MockitoBean
     private lateinit var maskinportenTokenClient: MaskinportenTokenClient
     @Autowired
     private lateinit var spkClient: SPKTjenestepensjonClient

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonServiceTest.kt
@@ -10,13 +10,13 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.LocalDate
 
 @SpringBootTest
 class SPKTjenestepensjonServiceTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var client: SPKTjenestepensjonClient
 
     @Autowired


### PR DESCRIPTION
Tjenestepensjon-simulering appen konsumerer eksterne API fra samhandlere, requestdata skal sendes til sporingslogg. 
Det utleveres ikke data på forespørsel fra samhandlere.