### PR TITLE
Pek 715 hente simulert tjenestepensjon spk

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/common/AlderUtil.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/common/AlderUtil.kt
@@ -1,0 +1,26 @@
+package no.nav.tjenestepensjon.simulering.common
+
+import no.nav.tjenestepensjon.simulering.model.domain.pen.Alder
+import java.time.LocalDate
+import java.time.Period
+
+object AlderUtil {
+
+    fun bestemAlderVedDato(fodselsdato: LocalDate, date: LocalDate): Alder {
+        val periode = Period.between(fodselsdato, date)
+        return Alder(periode.years, periode.months)
+    }
+
+    /*
+     * Funksjonen returnerer uttaksaderen ved uttaksdato, kan være lavere enn faktisk alder, når, f eks,
+     * bruker er født 1. i måned. Da skal brukeren ta ut pensjon en måned senere, selv om man er teknisk sett 1 måned eldre
+     * 1.1.2001 -> 1.2.2063 = 62 år og 0 måneder
+     */
+    fun bestemUttaksalderVedDato(fodselsdato: LocalDate, date: LocalDate): Alder {
+        val periode = Period.between(fodselsdato, date)
+        if (fodselsdato.dayOfMonth == 1) {
+            return Alder(periode.years, periode.months - 1)
+        }
+        return Alder(periode.years, periode.months)
+    }
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025Controller.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025Controller.kt
@@ -32,7 +32,9 @@ class TjenestepensjonSimuleringV2025Controller(
         return simuleringsresultat.second.fold(
             onSuccess = {
                 if (it.utbetalingsperioder.isNotEmpty()) {
-                    aggregerVellykketRespons(it, relevanteTpOrdninger)
+                    val aggregerVellykketRespons: SimulerTjenestepensjonResponseDto = aggregerVellykketRespons(it, relevanteTpOrdninger)
+                    log.debug { "Simulering vellykket: $aggregerVellykketRespons" }
+                    aggregerVellykketRespons
                 } else {
                     log.info { "Simulering fra ${it.tpLeverandoer} inneholder ingen utbetalingsperioder" }
                     SimulerTjenestepensjonResponseDto(ResultatTypeDto.INGEN_UTBETALINGSPERIODER_FRA_TP_ORDNING, "Simulering fra ${it.tpLeverandoer} inneholder ingen utbetalingsperioder", relevanteTpOrdninger)

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025Controller.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025Controller.kt
@@ -27,6 +27,7 @@ class TjenestepensjonSimuleringV2025Controller(
 
     @PostMapping("/v2025/tjenestepensjon/v1/simulering")
     fun simuler(@RequestBody request: SimulerTjenestepensjonRequestDto): SimulerTjenestepensjonResponseDto {
+        log.debug { "Simulerer tjenestepensjon for request: $request" }
         val simuleringsresultat = tjenestepensjonV2025Service.simuler(request)
         val relevanteTpOrdninger = simuleringsresultat.first
         return simuleringsresultat.second.fold(

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/afp/v1/AlderForDelingstallBeregner.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/afp/v1/AlderForDelingstallBeregner.kt
@@ -1,5 +1,6 @@
 package no.nav.tjenestepensjon.simulering.v2025.afp.v1
 
+import no.nav.tjenestepensjon.simulering.common.AlderUtil.bestemAlderVedDato
 import no.nav.tjenestepensjon.simulering.model.domain.pen.Alder
 import no.nav.tjenestepensjon.simulering.model.domain.pen.AlderForDelingstall
 import java.time.LocalDate
@@ -24,10 +25,5 @@ object AlderForDelingstallBeregner {
             return listOf(AlderForDelingstall(hoyesteAlderForDelingstall, uttaksdato))
         }
         return listOf(AlderForDelingstall(bestemAlderVedDato(fodselsdato, uttaksdato), uttaksdato))
-    }
-
-    fun bestemAlderVedDato(fodselsdato: LocalDate, date: LocalDate): Alder {
-        val periode = Period.between(fodselsdato, date)
-        return Alder(periode.years, periode.months)
     }
 }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapper.kt
@@ -1,5 +1,6 @@
 package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Ordning
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjon
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Utbetalingsperiode
@@ -8,6 +9,7 @@ import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk.dt
 import java.time.LocalDate
 
 object SPKMapper {
+    private val log = KotlinLogging.logger {}
 
     const val PROVIDER_FULLT_NAVN = "Statens Pensjonskasse"
 
@@ -28,8 +30,9 @@ object SPKMapper {
 
     private fun fjorAarSomManglerOpptjeningIPopp(): LocalDate = LocalDate.now().minusYears(1).withDayOfYear(1)
 
-    fun mapToResponse(response: SPKSimulerTjenestepensjonResponse) =
-        SimulertTjenestepensjon(
+    fun mapToResponse(response: SPKSimulerTjenestepensjonResponse): SimulertTjenestepensjon {
+        log.debug { "Mapping response from SPK $response" }
+        return SimulertTjenestepensjon(
             tpLeverandoer = PROVIDER_FULLT_NAVN,
             ordningsListe = response.inkludertOrdningListe.map { Ordning(it.tpnr) },
             utbetalingsperioder = response.utbetalingListe.flatMap { periode ->
@@ -39,6 +42,7 @@ object SPKMapper {
             aarsakIngenUtbetaling = response.aarsakIngenUtbetaling.map { it.statusBeskrivelse + ": " + it.ytelseType },
             betingetTjenestepensjonErInkludert = response.utbetalingListe.flatMap { it.delytelseListe }.any { it.ytelseType == "BTP" }
         )
+    }
 
     fun opprettUttaksliste(request: SimulerTjenestepensjonRequestDto): List<Uttak> {
         return SPKYtelse.hentAlleUnntattType(if (request.brukerBaOmAfp) SPKYtelse.BTP else SPKYtelse.OAFP)

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonClient.kt
@@ -26,6 +26,7 @@ class SPKTjenestepensjonClient(
 
     override fun simuler(request: SimulerTjenestepensjonRequestDto): Result<SimulertTjenestepensjon> {
         val dto = SPKMapper.mapToRequest(request)
+        log.debug { "Simulating tjenestepensjon 2025 hos SPK with request $dto" }
         sporingsloggService.loggUtgaaendeRequest(Organisasjon.SPK, request.pid, dto)
         try {
             val response = spkWebClient

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
@@ -2,6 +2,7 @@ package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tjenestepensjon.simulering.common.AlderUtil.bestemAlderVedDato
+import no.nav.tjenestepensjon.simulering.common.AlderUtil.bestemUttaksalderVedDato
 import no.nav.tjenestepensjon.simulering.ping.Pingable
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Maanedsutbetaling
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
@@ -50,7 +51,7 @@ class SPKTjenestepensjonService(private val client: SPKTjenestepensjonClient, pr
             .groupBy { it.fom }
             .map { (datoFra, ytelser) ->
                 val totalMaanedsBelop = ytelser.sumOf { it.maanedligBelop }
-                Maanedsutbetaling(datoFra, bestemAlderVedDato(foedselsdato, datoFra), totalMaanedsBelop)
+                Maanedsutbetaling(datoFra, bestemUttaksalderVedDato(foedselsdato, datoFra), totalMaanedsBelop)
             }
             .sortedBy { it.fraOgMedDato }
     }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
@@ -1,8 +1,8 @@
 package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tjenestepensjon.simulering.common.AlderUtil.bestemAlderVedDato
 import no.nav.tjenestepensjon.simulering.ping.Pingable
-import no.nav.tjenestepensjon.simulering.v2025.afp.v1.AlderForDelingstallBeregner.bestemAlderVedDato
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Maanedsutbetaling
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Utbetalingsperiode

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,5 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProfile name="dev-gcp">
+        <logger name="no.nav.tjenestepensjon" level="${logging.level.no.nav.tjenestepensjon:-DEBUG}" />
+    </springProfile>
+
+    <springProfile name="prod-gcp">
+        <logger name="no.nav.tjenestepensjon" level="${logging.level.no.nav.tjenestepensjon:-INFO}"/>
+    </springProfile>
+
     <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
@@ -23,12 +30,10 @@
         <appender-ref ref="STDOUT_JSON"/>
     </root>
 
-    <logger name="no.nav.tjenestepensjon" level="${logging.level.no.nav.tjenestepensjon:-INFO}"/>
     <logger name="org.springframework.security.oauth2"
             level="${logging.level.org.springframework.security.oauth2:-WARN}"/>
     <logger name="org.springframework.ws.client.MessageTracing"
             level="${logging.level.org.springframework.ws.client.MessageTracing:-WARN}"/>
     <logger name="org.springframework.ws.web" level="${logging.level.org.springframework.ws.web:-WARN}"/>
     <logger name="com.microsoft.aad" level="${logging.level.com.microsoft.aad:-WARN}"/>
-
 </configuration>

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/common/AlderUtilTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/common/AlderUtilTest.kt
@@ -1,0 +1,48 @@
+package no.nav.tjenestepensjon.simulering.common
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import java.time.LocalDate
+
+class AlderUtilTest {
+
+    @Test
+    fun `spesialhaandtering for uttaksalder for brukere foedt foerste i maaneden`() {
+
+        val foedselsdato = LocalDate.of(2001, 1, 1)
+        val uttaksdato = LocalDate.of(2063, 2, 1)
+        val alder = AlderUtil.bestemUttaksalderVedDato(foedselsdato, uttaksdato)
+        assertEquals(62, alder.aar)
+        assertEquals(0, alder.maaneder)
+    }
+
+    @Test
+    fun `bestem uttaksalder for en foedselsdato paa foerste desember`() {
+
+        val foedselsdato = LocalDate.of(2001, 12, 1)
+        val uttaksdato = LocalDate.of(2064, 1, 1)
+        val alder = AlderUtil.bestemUttaksalderVedDato(foedselsdato, uttaksdato)
+        assertEquals(62, alder.aar)
+        assertEquals(0, alder.maaneder)
+    }
+
+    @Test
+    fun `test bestem uttaksalder`() {
+
+        val foedselsdato = LocalDate.of(2000, 3, 15)
+        val uttaksdato = LocalDate.of(2062, 4, 1)
+        val alder = AlderUtil.bestemUttaksalderVedDato(foedselsdato, uttaksdato)
+        assertEquals(62, alder.aar)
+        assertEquals(0, alder.maaneder)
+    }
+
+    @Test
+    fun `test bestem uttaksalder for X aar og 11 maaneder`(){
+        val foedselsdato = LocalDate.of(2000, 3, 15)
+        val uttaksdato = LocalDate.of(2062, 3, 1)
+        val alder = AlderUtil.bestemUttaksalderVedDato(foedselsdato, uttaksdato)
+        assertEquals(61, alder.aar)
+        assertEquals(11, alder.maaneder)
+    }
+}


### PR DESCRIPTION
Fikser følgende feilsituasjon rapportert av Øyvind via Marion:

1. Bruker født 01.01.2001 ber om å beregne tjenestepensjon ved 62 år. 
2. Dette blir konvertert til uttaksdato 01.02.2063.
3. SPK leverer tjenestepensjon fra 01.02.2063.
4. Tjenestepensjon-simulering mapper uttaksdatoen til 62 år og 1 måned, selv om det burde vært 62 år og 0 måneder