### PR TITLE
The action gradle/gradle-build-action has been replaced by gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,19 +8,15 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-      # Checkout
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
-
-      # Build
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: current
-          arguments: build
-        env:
-          GITHUB_TOKEN: ${{ secrets.READER_TOKEN }}
+      - name: Build
+        run: ./gradlew clean build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
 
       # Build
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: current
           arguments: build


### PR DESCRIPTION
Oppgraderer utdatert github-action for å bygge pull-request med gradle
[https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle)