### PR TITLE
Øke cpu-request i prod

### DIFF
--- a/.nais/nais-prod-gcp.yaml
+++ b/.nais/nais-prod-gcp.yaml
@@ -15,7 +15,7 @@ spec:
     limits:
       memory: 4096Mi
     requests:
-      cpu: 50m
+      cpu: 150m
       memory: 2048Mi
   port: 8080
   ingresses:


### PR DESCRIPTION
Et forsøk til å få jevnere bruk av CPU i prod. Høyt forbruk skyldes "spikes" i cpu-bruk som skjer, sannsynligvis, ved start av nye podder:
[https://console.nav.cloud.nais.io/team/pensjonskalkulator/prod-gcp/app/tjenestepensjon-simulering/utilization](https://console.nav.cloud.nais.io/team/pensjonskalkulator/prod-gcp/app/tjenestepensjon-simulering/utilization)
```
CPU utilization:
767.61% of 0.20 cores
```
 