### PR TITLE
PEK-835 bruk spk som siste ordning, hvis spk er med i tp-forholdsliste

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/FinnSisteTpOrdningNavService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/FinnSisteTpOrdningNavService.kt
@@ -1,0 +1,7 @@
+package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service
+
+import org.springframework.stereotype.Service
+
+@Service
+class FinnSisteTpOrdningNavService : FinnSisteTpOrdningService {
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/FinnSisteTpOrdningService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/FinnSisteTpOrdningService.kt
@@ -1,0 +1,24 @@
+package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service
+
+import no.nav.tjenestepensjon.simulering.model.domain.TpOrdningDto
+
+interface FinnSisteTpOrdningService {
+
+    /*
+    *  En enkel versjon av siste ordning som returnerer "spk" om det ligger i listen
+    *  eller første i listen. Liste kan ikke være tom
+    *
+    * Avventer en avansert versjon av FinnSisteOrdning service fra SPK
+    *
+    * */
+    fun finnSisteOrdning(tpOrdninger: List<TpOrdningDto>): String {
+        val sisteOrdning = tpOrdninger
+            .flatMap { it.alias }
+            .any { "spk".equals(it, ignoreCase = true) }
+        return if (sisteOrdning) "spk" else tpOrdninger.flatMap { it.alias }.firstOrNull() ?: TP_ORDNING_UTEN_ALIAS
+    }
+
+    companion object{
+        const val TP_ORDNING_UTEN_ALIAS = "tp-ordning er uten alias i tpregisteret"
+    }
+}

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/FinnSisteTpOrdningNavServiceTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/FinnSisteTpOrdningNavServiceTest.kt
@@ -1,0 +1,56 @@
+package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service
+
+import no.nav.tjenestepensjon.simulering.model.domain.TpOrdningDto
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.FinnSisteTpOrdningService.Companion.TP_ORDNING_UTEN_ALIAS
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class FinnSisteTpOrdningNavServiceTest{
+
+    @Autowired
+    private lateinit var finnSisteTpOrdningNavService: FinnSisteTpOrdningService
+
+    @Test
+    fun `finn siste ordning for tp-ordning uten alias`(){
+
+        val sisteOrdning = finnSisteTpOrdningNavService.finnSisteOrdning(listOf(
+            TpOrdningDto("navn", "tpNr", "orgNr", emptyList())
+        ))
+
+        assertNotNull(sisteOrdning)
+        assertEquals(TP_ORDNING_UTEN_ALIAS, sisteOrdning)
+    }
+
+    @Test
+    fun `finn siste ordning i en liste uten SPK retunerer foerste i listen`(){
+
+        val tpOrdning = TpOrdningDto("navn", "tpNr", "orgNr", listOf("navn"))
+        val sisteOrdning = finnSisteTpOrdningNavService.finnSisteOrdning(listOf(
+            tpOrdning,
+            TpOrdningDto("navn2", "tpNr2", "orgNr2", listOf("navn2")),
+            TpOrdningDto("navn3", "tpNr3", "orgNr3", listOf("navn3"))
+        ))
+
+        assertNotNull(sisteOrdning)
+        assertEquals(tpOrdning.alias.first(), sisteOrdning)
+    }
+
+    @Test
+    fun `finn siste ordning i en liste MED SPK retunerer SPK med lowercase`(){
+
+        val tpOrdning = TpOrdningDto("navn", "tpNr", "orgNr", listOf("navn"))
+        val spk = TpOrdningDto("Statens Pensjonskasse", "tpNr2", "orgNr2", listOf("SPK"))
+        val sisteOrdning = finnSisteTpOrdningNavService.finnSisteOrdning(listOf(
+            tpOrdning,
+            spk,
+            TpOrdningDto("navn3", "tpNr3", "orgNr3", listOf("navn3"))
+        ))
+
+        assertNotNull(sisteOrdning)
+        assertEquals(spk.alias.first().lowercase(), sisteOrdning)
+    }
+}

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/FinnSisteTpOrdningNavServiceTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/FinnSisteTpOrdningNavServiceTest.kt
@@ -5,14 +5,10 @@ import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.FinnSi
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 
-@SpringBootTest
 class FinnSisteTpOrdningNavServiceTest{
 
-    @Autowired
-    private lateinit var finnSisteTpOrdningNavService: FinnSisteTpOrdningService
+    private val finnSisteTpOrdningNavService = FinnSisteTpOrdningNavService()
 
     @Test
     fun `finn siste ordning for tp-ordning uten alias`(){
@@ -26,7 +22,7 @@ class FinnSisteTpOrdningNavServiceTest{
     }
 
     @Test
-    fun `finn siste ordning i en liste uten SPK retunerer foerste i listen`(){
+    fun `finn siste ordning i en liste uten SPK returnerer foerste i listen`(){
 
         val tpOrdning = TpOrdningDto("navn", "tpNr", "orgNr", listOf("navn"))
         val sisteOrdning = finnSisteTpOrdningNavService.finnSisteOrdning(listOf(
@@ -40,7 +36,7 @@ class FinnSisteTpOrdningNavServiceTest{
     }
 
     @Test
-    fun `finn siste ordning i en liste MED SPK retunerer SPK med lowercase`(){
+    fun `finn siste ordning i en liste MED SPK returnerer SPK med lowercase`(){
 
         val tpOrdning = TpOrdningDto("navn", "tpNr", "orgNr", listOf("navn"))
         val spk = TpOrdningDto("Statens Pensjonskasse", "tpNr2", "orgNr2", listOf("SPK"))


### PR DESCRIPTION
`Finn Siste Ordning` tjeneste som returnerer `spk`, når det ligger `spk` i listen i tjenestepensjon-forhold fra tpregisteret