### PR TITLE
Feature/pek 896 haandtere feil ved henting av token fra maskinporten

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenToken.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenToken.kt
@@ -36,6 +36,7 @@ class MaskinportenToken(
     }
 
     fun fetchToken(scope: String): String {
+        log.debug { "Henter token fra maskinporten med scope(s): ${scope}" }
         val rsaKey = RSAKey.parse(clientJwk)
         val signedJWT = SignedJWT(
             JWSHeader.Builder(JWSAlgorithm.RS256)
@@ -47,7 +48,7 @@ class MaskinportenToken(
                 .issuer(clientId)
                 .claim("scope", scope)
                 .issueTime(Date())
-                .expirationTime(twoMinutesFromNow())
+                .expirationTime(getExpireAfter())
                 .build()
         )
         signedJWT.sign(RSASSASigner(rsaKey.toRSAPrivateKey()))
@@ -65,7 +66,7 @@ class MaskinportenToken(
         return response!!.access_token
     }
 
-    fun twoMinutesFromNow(): Date {
+    fun getExpireAfter(): Date {
         val calendar = Calendar.getInstance()
         calendar.time = Date();
         calendar.add(Calendar.SECOND, REQUEST_TOKEN_TO_EXPIRE_AFTER_SECONDS)
@@ -82,7 +83,7 @@ class MaskinportenToken(
 
     companion object {
         private val EXPIRE_AFTER_TIME_UNITS = TimeUnit.SECONDS
-        private const val EXPIRE_AFTER: Long = 100
+        private const val EXPIRE_AFTER: Long = 50
         private const val REQUEST_TOKEN_TO_EXPIRE_AFTER_SECONDS: Int = (EXPIRE_AFTER + 20).toInt()
     }
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenToken.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenToken.kt
@@ -37,7 +37,6 @@ class MaskinportenToken(
     }
 
     fun fetchToken(scope: String): String {
-        log.debug { "Henter token fra maskinporten med scope(s): ${scope}" }
         val rsaKey = RSAKey.parse(clientJwk)
         val signedJWT = SignedJWT(
             JWSHeader.Builder(JWSAlgorithm.RS256)
@@ -68,7 +67,7 @@ class MaskinportenToken(
                 }
             )
             .block()
-        log.info { "Hentet token fra maskinporten med scope(s): ${scope}" }
+        log.debug { "Hentet token fra maskinporten med scope(s): ${scope}" }
         return response!!.access_token
     }
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenToken.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenToken.kt
@@ -1,5 +1,7 @@
 package no.nav.tjenestepensjon.simulering.v2.consumer
 
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.LoadingCache
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 @Service
 class MaskinportenToken(
@@ -24,8 +27,15 @@ class MaskinportenToken(
     @Value("\${maskinporten.token-endpoint-url}") val endpoint: String,
 ) {
     private val log = KotlinLogging.logger {}
+    private val tokenCache: LoadingCache<String, String> = Caffeine.newBuilder()
+        .expireAfterWrite(EXPIRE_AFTER, EXPIRE_AFTER_TIME_UNITS)
+        .build { k: String -> fetchToken(k) }
 
     fun getToken(scope: String): String {
+        return tokenCache.get(scope)
+    }
+
+    fun fetchToken(scope: String): String {
         val rsaKey = RSAKey.parse(clientJwk)
         val signedJWT = SignedJWT(
             JWSHeader.Builder(JWSAlgorithm.RS256)
@@ -37,7 +47,7 @@ class MaskinportenToken(
                 .issuer(clientId)
                 .claim("scope", scope)
                 .issueTime(Date())
-                .expirationTime(twoMinutesFromDate(Date()))
+                .expirationTime(twoMinutesFromNow())
                 .build()
         )
         signedJWT.sign(RSASSASigner(rsaKey.toRSAPrivateKey()))
@@ -55,13 +65,13 @@ class MaskinportenToken(
         return response!!.access_token
     }
 
-    fun twoMinutesFromDate(date: Date): Date {
+    fun twoMinutesFromNow(): Date {
         val calendar = Calendar.getInstance()
-        calendar.time = date;
-        calendar.add(Calendar.MINUTE, 2)
-
+        calendar.time = Date();
+        calendar.add(Calendar.SECOND, REQUEST_TOKEN_TO_EXPIRE_AFTER_SECONDS)
         return calendar.time
     }
+
 
     data class MaskinportenTokenResponse(
         val access_token: String,
@@ -69,5 +79,11 @@ class MaskinportenToken(
         val expires_in: Int,
         val scope: String,
     )
+
+    companion object {
+        private val EXPIRE_AFTER_TIME_UNITS = TimeUnit.SECONDS
+        private const val EXPIRE_AFTER: Long = 100
+        private const val REQUEST_TOKEN_TO_EXPIRE_AFTER_SECONDS: Int = (EXPIRE_AFTER + 20).toInt()
+    }
 
 }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenTokenClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenTokenClient.kt
@@ -9,7 +9,6 @@ class MaskinportenTokenClient(val maskinportenToken: MaskinportenToken) {
     private val log = KotlinLogging.logger {}
 
     fun pensjonsimuleringToken(scope: String): String {
-        log.info { "Henter maskinporten token for $scope" }
         return try {
             maskinportenToken.getToken(scope)
         } catch (exc: Throwable) {

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenTokenClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenTokenClient.kt
@@ -3,6 +3,7 @@ package no.nav.tjenestepensjon.simulering.v2.consumer
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tjenestepensjon.simulering.v2.exceptions.ConnectToMaskinPortenException
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientException
 
 @Service
 class MaskinportenTokenClient(val maskinportenToken: MaskinportenToken) {
@@ -11,7 +12,7 @@ class MaskinportenTokenClient(val maskinportenToken: MaskinportenToken) {
     fun pensjonsimuleringToken(scope: String): String {
         return try {
             maskinportenToken.getToken(scope)
-        } catch (exc: Throwable) {
+        } catch (exc: WebClientException) {
             log.error(exc) { "Error while retrieving token from provider: ${exc.message}" }
             throw ConnectToMaskinPortenException(exc.message)
         }

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenTokenTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2/consumer/MaskinportenTokenTest.kt
@@ -1,0 +1,69 @@
+package no.nav.tjenestepensjon.simulering.v2.consumer
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.web.reactive.function.client.WebClient
+
+@ExtendWith(MockitoExtension::class)
+class MaskinportenTokenTest{
+
+    @Mock
+    private lateinit var webClient: WebClient
+
+    private lateinit var maskinportenClient: MaskinportenToken
+
+    private var fetchTokenCallCount = 0
+
+    @BeforeEach
+    fun setUp() {
+        // Set up the WebClient mock to return a MaskinportenToken
+        maskinportenClient = object : MaskinportenToken(webClient, "clientId", "clientJwk", "issuer", "endpoint") {
+            override fun fetchToken(scope: String): String {
+                // Return a mock token instead of performing real signing
+                fetchTokenCallCount++
+                return when (scope) {
+                    "test-scope" -> "test-token"
+                    "another-scope" -> "another-token"
+                    else -> throw RuntimeException("Unexpected scope: $scope")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should fetch token from cache when available`() {
+        // First call, fetchToken should be called
+        val countBeforeTestStart = fetchTokenCallCount
+        val token1 = maskinportenClient.getToken("test-scope")
+        assertEquals("test-token", token1)
+
+        // Second call with the same scope, token should be retrieved from cache
+        val token2 = maskinportenClient.getToken("test-scope")
+        assertEquals("test-token", token2)
+
+        // Assert that fetchToken was called only once
+        assertEquals(
+            countBeforeTestStart + 1,
+            fetchTokenCallCount,
+            "fetchToken should be called only once for 'test-scope'"
+        )
+    }
+
+    @Test
+    fun `should fetch new token when scope is different`() {
+        // First call for "test-scope"
+        val countBeforeTestStart = fetchTokenCallCount
+        maskinportenClient.getToken("test-scope")
+
+        // Call for a different scope, fetchToken should be called again
+        val token = maskinportenClient.getToken("another-scope")
+        assertEquals("another-token", token)
+
+        // Assert that fetchToken was called twice in total (once for each scope)
+        assertEquals(countBeforeTestStart + 2, fetchTokenCallCount, "fetchToken should be called once per unique scope")
+    }
+}


### PR DESCRIPTION
1. Cache hentet tokens
2. Retry ved "retryable" feil
3. Logge hele feilmeldingen ved feilet request

Vi får kanskje vite hva maskinporten sier, når den returnerer 400 Bad request som skjer iblant