### PR TITLE
PEK-959 legg til tpNummer til respons fra simulering. Oppdater log

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/domain/SimulertTjenestepensjon.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/domain/SimulertTjenestepensjon.kt
@@ -13,6 +13,7 @@ data class Ordning(val tpNummer: String)
 
 open class SimulertTjenestepensjonMedMaanedsUtbetalinger(
     val tpLeverandoer: String,
+    val tpNummer: String,
     var ordningsListe: List<Ordning> = emptyList(),
     var utbetalingsperioder: List<Maanedsutbetaling> = emptyList(),
     var aarsakIngenUtbetaling: List<String> = emptyList(),

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/Tjenestepensjon2025Aggregator.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/Tjenestepensjon2025Aggregator.kt
@@ -13,6 +13,7 @@ object Tjenestepensjon2025Aggregator {
             simuleringsResultatStatus = SimuleringsResultatStatusDto(ResultatTypeDto.SUCCESS),
             simuleringsResultat = SimuleringsResultatDto(
                 tpLeverandoer = simulertTjenestepensjon.tpLeverandoer,
+                tpNummer = simulertTjenestepensjon.tpNummer,
                 utbetalingsperioder = aggregerTilAarligePerioder(simulertTjenestepensjon.utbetalingsperioder),
                 betingetTjenestepensjonErInkludert = simulertTjenestepensjon.betingetTjenestepensjonErInkludert
             ),

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/response/SimulerTjenestepensjonResponseDto.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/response/SimulerTjenestepensjonResponseDto.kt
@@ -28,6 +28,7 @@ enum class ResultatTypeDto {
 
 data class SimuleringsResultatDto(
     val tpLeverandoer: String,
+    val tpNummer: String,
     val utbetalingsperioder: List<UtbetalingPerAlder>,
     val betingetTjenestepensjonErInkludert: Boolean,
 )

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
@@ -1,6 +1,7 @@
 package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tjenestepensjon.simulering.model.domain.TpOrdningDto
 import no.nav.tjenestepensjon.simulering.ping.PingResponse
 import no.nav.tjenestepensjon.simulering.service.TpClient
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
@@ -54,8 +55,7 @@ class TjenestepensjonV2025Service(
             }
         }
 
-        // Returnerer TomSimuleringFraTpOrdningException derom alle utbetalingsperioder er tomme og/eller tp-ordninger ikke er støttet
-        log.info { "Simulering fra ${tpOrdningerNavn} inneholder ingen utbetalingsperioder" }
+        log.info { "Ingen simulering fra ${tpOrdninger}: ${simulertTpListe.map { it.exceptionOrNull()?.message }.joinToString(";")}" }
         return tpOrdningerNavn to simulertTpListe.first()
     }
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonService.kt
@@ -44,6 +44,7 @@ class KLPTjenestepensjonService(@Value("\${spring.profiles.active:}") private va
 
         val klpResponseMock = SimulertTjenestepensjonMedMaanedsUtbetalinger(
             tpLeverandoer = "Kommunal Landspensjonskasse",
+            tpNummer = tpNummer,
             ordningsListe = arrayListOf(Ordning("3100")),
             utbetalingsperioder = arrayListOf(maanedsutbetalingMock, maanedsutbetalingMock2),
             aarsakIngenUtbetaling = emptyList(),
@@ -64,6 +65,7 @@ class KLPTjenestepensjonService(@Value("\${spring.profiles.active:}") private va
                         Result.success(
                             SimulertTjenestepensjonMedMaanedsUtbetalinger(
                                 tpLeverandoer = KLPMapper.PROVIDER_FULLT_NAVN,
+                                tpNummer = tpNummer,
                                 ordningsListe = it.ordningsListe,
                                 utbetalingsperioder = TpUtil.grupperMedDatoFra(
                                     eksluderYtelser(it.utbetalingsperioder),

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
@@ -32,6 +32,7 @@ class SPKTjenestepensjonService(private val client: SPKTjenestepensjonClient, pr
                         Result.success(
                             SimulertTjenestepensjonMedMaanedsUtbetalinger(
                                 tpLeverandoer = SPKMapper.PROVIDER_FULLT_NAVN,
+                                tpNummer = tpNummer,
                                 ordningsListe = it.ordningsListe,
                                 utbetalingsperioder = TpUtil.grupperMedDatoFra(fjerneAfp(it.utbetalingsperioder), request.foedselsdato),
                                 betingetTjenestepensjonErInkludert = it.betingetTjenestepensjonErInkludert,

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025ControllerTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025ControllerTest.kt
@@ -72,6 +72,7 @@ class TjenestepensjonSimuleringV2025ControllerTest {
         )
         val mockRespons = SimulertTjenestepensjonMedMaanedsUtbetalinger(
             tpLeverandoer = "pensjonskasse",
+            tpNummer = "123456",
             ordningsListe = emptyList(),
             utbetalingsperioder = perioder,
             aarsakIngenUtbetaling = emptyList(),
@@ -104,6 +105,7 @@ class TjenestepensjonSimuleringV2025ControllerTest {
                             },
                             "simuleringsResultat": {
                                     "tpLeverandoer": "${mockRespons.tpLeverandoer}",
+                                    "tpNummer": "${mockRespons.tpNummer}",
                                     "utbetalingsperioder": [
                                         {
                                             "startAlder": {

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/Tjenestepensjon2025AggregatorTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/Tjenestepensjon2025AggregatorTest.kt
@@ -17,6 +17,7 @@ class Tjenestepensjon2025AggregatorTest {
     fun `aggreger varierende maanedsperioder inkludert ved aarskifte til perioder med slutt alder`() {
         val simulertTjenestepensjon = SimulertTjenestepensjonMedMaanedsUtbetalinger(
             tpLeverandoer = "tpLeverandoer",
+            tpNummer = "5555",
             ordningsListe = listOf(Ordning("3010")),
             utbetalingsperioder = listOf(
                 Maanedsutbetaling(
@@ -44,6 +45,7 @@ class Tjenestepensjon2025AggregatorTest {
         assertEquals(ResultatTypeDto.SUCCESS, result.simuleringsResultatStatus.resultatType)
         assertEquals(simulertTjenestepensjon.utbetalingsperioder.size, result.simuleringsResultat?.utbetalingsperioder?.size)
         assertEquals(simulertTjenestepensjon.tpLeverandoer, result.simuleringsResultat?.tpLeverandoer)
+        assertEquals(simulertTjenestepensjon.tpNummer, result.simuleringsResultat?.tpNummer)
 
         assertEquals(simulertTjenestepensjon.utbetalingsperioder[0].fraOgMedAlder, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.startAlder)
         assertEquals(simulertTjenestepensjon.utbetalingsperioder[1].fraOgMedAlder.aar - 1, result.simuleringsResultat?.utbetalingsperioder?.get(0)?.sluttAlder?.aar)
@@ -64,6 +66,7 @@ class Tjenestepensjon2025AggregatorTest {
     fun `aggregering haandterer tom liste`() {
         val simulertTjenestepensjon = SimulertTjenestepensjonMedMaanedsUtbetalinger(
             tpLeverandoer = "pensjonskasse",
+            tpNummer = "999999",
             ordningsListe = listOf(Ordning("3010")),
             utbetalingsperioder = emptyList(),
             aarsakIngenUtbetaling = listOf("Ingen utbetaling"),
@@ -75,5 +78,6 @@ class Tjenestepensjon2025AggregatorTest {
         assertEquals(ResultatTypeDto.SUCCESS, result.simuleringsResultatStatus.resultatType)
         assertTrue(result.simuleringsResultat!!.utbetalingsperioder.isEmpty())
         assertEquals(simulertTjenestepensjon.tpLeverandoer, result.simuleringsResultat!!.tpLeverandoer)
+        assertEquals(simulertTjenestepensjon.tpNummer, result.simuleringsResultat!!.tpNummer)
     }
 }

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025ServiceTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025ServiceTest.kt
@@ -45,7 +45,7 @@ class TjenestepensjonV2025ServiceTest {
     fun `simuler success fra spk`() {
         val req = dummyRequest("1963-02-05")
         `when`(tp.findTPForhold(req.pid)).thenReturn(listOf(dummyTpOrdning("3010")))
-        `when`(spk.simuler(req,"3010")).thenReturn(dummyResult("spk"))
+        `when`(spk.simuler(req,"3010")).thenReturn(dummyResult("spk", "3010"))
 
         val res: Pair<List<String>, Result<SimulertTjenestepensjonMedMaanedsUtbetalinger>> = tjenestepensjonV2025Service.simuler(req)
 
@@ -53,6 +53,7 @@ class TjenestepensjonV2025ServiceTest {
         val tjenestepensjon = res.second.getOrNull()
         assertNotNull(tjenestepensjon)
         assertEquals("spk", tjenestepensjon.tpLeverandoer)
+        assertEquals("3010", tjenestepensjon.tpNummer)
         assertEquals(1, tjenestepensjon.ordningsListe.size)
         assertEquals(1, tjenestepensjon.utbetalingsperioder.size)
     }
@@ -116,7 +117,7 @@ class TjenestepensjonV2025ServiceTest {
     fun `simuler success fra klp 4080`() {
         val req = dummyRequest("1963-02-05")
         `when`(tp.findTPForhold(req.pid)).thenReturn(listOf(dummyTpOrdning("4080")))
-        `when`(klp.simuler(req, "4080")).thenReturn(dummyResult("klp"))
+        `when`(klp.simuler(req, "4080")).thenReturn(dummyResult("klp", "4080"))
 
         val res: Pair<List<String>, Result<SimulertTjenestepensjonMedMaanedsUtbetalinger>> = tjenestepensjonV2025Service.simuler(req)
 
@@ -124,6 +125,7 @@ class TjenestepensjonV2025ServiceTest {
         val tjenestepensjon = res.second.getOrNull()
         assertNotNull(tjenestepensjon)
         assertEquals("klp", tjenestepensjon.tpLeverandoer)
+        assertEquals("4080", tjenestepensjon.tpNummer)
         assertEquals(1, tjenestepensjon.ordningsListe.size)
         assertEquals(1, tjenestepensjon.utbetalingsperioder.size)
     }
@@ -132,7 +134,7 @@ class TjenestepensjonV2025ServiceTest {
     fun `simuler success fra klp 3200`() {
         val req = dummyRequest("1963-02-05")
         `when`(tp.findTPForhold(req.pid)).thenReturn(listOf(dummyTpOrdning("3200")))
-        `when`(klp.simuler(req, "3200")).thenReturn(dummyResult("klp"))
+        `when`(klp.simuler(req, "3200")).thenReturn(dummyResult("klp", "3200"))
 
         val res: Pair<List<String>, Result<SimulertTjenestepensjonMedMaanedsUtbetalinger>> = tjenestepensjonV2025Service.simuler(req)
 
@@ -140,6 +142,7 @@ class TjenestepensjonV2025ServiceTest {
         val tjenestepensjon = res.second.getOrNull()
         assertNotNull(tjenestepensjon)
         assertEquals("klp", tjenestepensjon.tpLeverandoer)
+        assertEquals("3200", tjenestepensjon.tpNummer)
         assertEquals(1, tjenestepensjon.ordningsListe.size)
         assertEquals(1, tjenestepensjon.utbetalingsperioder.size)
     }
@@ -175,9 +178,10 @@ class TjenestepensjonV2025ServiceTest {
 
         fun dummyTpOrdning(tpNummer: String) = TpOrdningDto("Statens pensjonskasse", tpNummer, "123456789", listOf("spk"))
 
-        fun dummyResult(leverandoer: String) = Result.success(
+        fun dummyResult(leverandoer: String, tpNummer: String) = Result.success(
             SimulertTjenestepensjonMedMaanedsUtbetalinger(
                 leverandoer,
+                tpNummer,
                 listOf(Ordning("3010")),
                 listOf(
                     Maanedsutbetaling(


### PR DESCRIPTION
Vi fjerner tpOrdning navn gradvis, slik at Frontend skal styre navn og diverse tekster og lenker selv.