### PR TITLE
Mock klp respons nærmere klient. Skrive tester som dekker verdikjeden

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/domain/SimulertTjenestepensjon.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/domain/SimulertTjenestepensjon.kt
@@ -7,7 +7,11 @@ open class SimulertTjenestepensjon(
     var aarsakIngenUtbetaling: List<String> = emptyList(),
     val betingetTjenestepensjonErInkludert: Boolean,
     var serviceData: List<String> = emptyList(),
-)
+){
+    override fun toString(): String {
+        return "(tpLeverandoer='$tpLeverandoer', ordningsListe=$ordningsListe, utbetalingsperioder=$utbetalingsperioder, aarsakIngenUtbetaling=$aarsakIngenUtbetaling, betingetTjenestepensjonErInkludert=$betingetTjenestepensjonErInkludert"
+    }
+}
 
 data class Ordning(val tpNummer: String)
 
@@ -19,4 +23,8 @@ open class SimulertTjenestepensjonMedMaanedsUtbetalinger(
     var aarsakIngenUtbetaling: List<String> = emptyList(),
     val betingetTjenestepensjonErInkludert: Boolean = false,
     var serviceData: List<String> = emptyList(),
-)
+){
+    override fun toString(): String {
+        return "SimulertTjenestepensjonMedMaanedsUtbetalinger(tpLeverandoer='$tpLeverandoer', tpNummer='$tpNummer', ordningsListe=$ordningsListe, utbetalingsperioder=$utbetalingsperioder, aarsakIngenUtbetaling=$aarsakIngenUtbetaling, betingetTjenestepensjonErInkludert=$betingetTjenestepensjonErInkludert"
+    }
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
@@ -1,15 +1,18 @@
 package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import no.nav.tjenestepensjon.simulering.model.domain.TpOrdningDto
 import no.nav.tjenestepensjon.simulering.ping.PingResponse
 import no.nav.tjenestepensjon.simulering.service.TpClient
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.*
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.BrukerErIkkeMedlemException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TomSimuleringFraTpOrdningException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpOrdningStoettesIkkeException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpregisteretException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.KLPTjenestepensjonService
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk.SPKTjenestepensjonService
 import org.springframework.stereotype.Service
+
 @Service
 class TjenestepensjonV2025Service(
     private val tp: TpClient,

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
@@ -54,7 +54,7 @@ object KLPMapper {
             aarsakIngenUtbetaling = response.arsakIngenUtbetaling,
             betingetTjenestepensjonErInkludert = response.utbetalingsListe.any { it.ytelseType == KLPYtelse.BTP.name }
         ).apply {
-            serviceData = listOf("Request: ${dto?.toString()}","Response: $response", "Mapped to: $this")
+            serviceData = listOf("Request: ${dto?.toString()}","Response: $response")
         }
 
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonClient.kt
@@ -10,7 +10,10 @@ import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.Si
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TjenestepensjonSimuleringException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.TjenestepensjonV2025Client
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.TjenestepensjonV2025Client.Companion.TJENESTE
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.InkludertOrdning
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.KLPSimulerTjenestepensjonResponse
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.Utbetaling
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientRequestException
@@ -20,39 +23,59 @@ import org.springframework.web.reactive.function.client.bodyToMono
 @Service
 class KLPTjenestepensjonClient(
     private val klpWebClient: WebClient,
-    private val sporingsloggService: SporingsloggService
+    private val sporingsloggService: SporingsloggService,
+    @Value("\${spring.profiles.active:}") private val activeProfiles: String,
 ) : TjenestepensjonV2025Client, Pingable {
     private val log = KotlinLogging.logger {}
 
     override fun simuler(request: SimulerTjenestepensjonRequestDto, tpNummer: String): Result<SimulertTjenestepensjon> {
-        val dto = KLPMapper.mapToRequest(request)
-        sporingsloggService.loggUtgaaendeRequest(Organisasjon.KLP, request.pid, dto)
-        try {
-            val response = klpWebClient
-                .post()
-                .uri("$SIMULER_PATH/$tpNummer")
-                .bodyValue(dto)
-                .retrieve()
-                .bodyToMono<KLPSimulerTjenestepensjonResponse>()
-                .block()
-            return response?.let { Result.success(KLPMapper.mapToResponse(it, KLPMapper.mapToLoggableRequestDto(request)) ) } ?: Result.failure(TjenestepensjonSimuleringException("No response body"))
-        } catch (e: WebClientResponseException) {
-            val errorMsg = "Failed to simulate tjenestepensjon 2025 hos KLP ${e.responseBodyAsString}"
-            log.error(e) { errorMsg }
-            return Result.failure(TjenestepensjonSimuleringException(errorMsg))
-        } catch (e: WebClientRequestException) {
-            log.error(e) { "Failed to send request to simulate tjenestepensjon 2025 hos KLP med url ${e.uri}" }
-            return Result.failure(TjenestepensjonSimuleringException("Failed to send request to simulate tjenestepensjon 2025 hos KLP"))
+        val response = if (activeProfiles.contains("dev-gcp")) {
+            provideMockResponse(request)
+        } else {
+            val dto = KLPMapper.mapToRequest(request)
+            sporingsloggService.loggUtgaaendeRequest(Organisasjon.KLP, request.pid, dto)
+
+            try {
+                klpWebClient
+                    .post()
+                    .uri("$SIMULER_PATH/$tpNummer")
+                    .bodyValue(dto)
+                    .retrieve()
+                    .bodyToMono<KLPSimulerTjenestepensjonResponse>()
+                    .block()
+            } catch (e: WebClientResponseException) {
+                val errorMsg = "Failed to simulate tjenestepensjon 2025 hos KLP ${e.responseBodyAsString}"
+                log.error(e) { errorMsg }
+                return Result.failure(TjenestepensjonSimuleringException(errorMsg))
+            } catch (e: WebClientRequestException) {
+                log.error(e) { "Failed to send request to simulate tjenestepensjon 2025 hos KLP med url ${e.uri}" }
+                return Result.failure(TjenestepensjonSimuleringException("Failed to send request to simulate tjenestepensjon 2025 hos KLP"))
+            }
         }
+        return response?.let { Result.success(KLPMapper.mapToResponse(it, KLPMapper.mapToLoggableRequestDto(request))) } ?: Result.failure(TjenestepensjonSimuleringException("No response body"))
     }
 
     override fun ping(): PingResponse {
         return PingResponse(PROVIDER, TJENESTE, "Støttes ikke")
     }
 
+
     companion object {
-        private const val SIMULER_PATH = "/api/oftp/simulering"
+        const val SIMULER_PATH = "/api/oftp/simulering"
         private const val PING_PATH = ""
         private const val PROVIDER = "KLP"
+
+        fun provideMockResponse(request: SimulerTjenestepensjonRequestDto): KLPSimulerTjenestepensjonResponse {
+            return KLPSimulerTjenestepensjonResponse(
+                inkludertOrdningListe = listOf(InkludertOrdning("3100")),
+                utbetalingsListe = listOf(
+                    Utbetaling(fraOgMedDato = request.uttaksdato, manedligUtbetaling = 3576, arligUtbetaling = 42914, ytelseType = "PAASLAG"),
+                    Utbetaling(fraOgMedDato = request.uttaksdato.plusYears(5), manedligUtbetaling = 2232, arligUtbetaling = 26779, ytelseType = "APOF2020"),
+                    Utbetaling(fraOgMedDato = request.uttaksdato, manedligUtbetaling = 884, arligUtbetaling = 10609, ytelseType = "BTP"),
+                ),
+                arsakIngenUtbetaling = emptyList(),
+                betingetTjenestepensjonErInkludert = false,
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonService.kt
@@ -1,23 +1,19 @@
 package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import no.nav.tjenestepensjon.simulering.common.AlderUtil.bestemUttaksalderVedDato
 import no.nav.tjenestepensjon.simulering.ping.Pingable
 import no.nav.tjenestepensjon.simulering.service.FeatureToggleService
 import no.nav.tjenestepensjon.simulering.service.FeatureToggleService.Companion.SIMULER_KLP
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Maanedsutbetaling
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Ordning
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Utbetalingsperiode
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TomSimuleringFraTpOrdningException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpOrdningStoettesIkkeException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.TpUtil
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 @Service
-class KLPTjenestepensjonService(@Value("\${spring.profiles.active:}") private val activeProfiles: String, private val client: KLPTjenestepensjonClient, private val featureToggleService: FeatureToggleService) : Pingable {
+class KLPTjenestepensjonService(private val client: KLPTjenestepensjonClient, private val featureToggleService: FeatureToggleService) : Pingable {
     private val log = KotlinLogging.logger {}
     private val TP_ORDNING = "klp"
 
@@ -26,36 +22,6 @@ class KLPTjenestepensjonService(@Value("\${spring.profiles.active:}") private va
             return loggOgReturn()
         }
 
-        if (activeProfiles.contains("prod-gcp")) {
-            return simulerv2(request, tpNummer)
-        }
-
-        val maanedsutbetalingMock = Maanedsutbetaling(
-            fraOgMedDato = request.uttaksdato,
-            fraOgMedAlder = bestemUttaksalderVedDato(fodselsdato = request.foedselsdato, date = request.uttaksdato),
-            maanedsBeloep = 5000,
-        )
-
-        val maanedsutbetalingMock2 = Maanedsutbetaling(
-            fraOgMedDato = request.uttaksdato.plusYears(5),
-            fraOgMedAlder = bestemUttaksalderVedDato(fodselsdato = request.foedselsdato, date = request.uttaksdato.plusYears(5)),
-            maanedsBeloep = 6000,
-        )
-
-        val klpResponseMock = SimulertTjenestepensjonMedMaanedsUtbetalinger(
-            tpLeverandoer = "Kommunal Landspensjonskasse",
-            tpNummer = tpNummer,
-            ordningsListe = arrayListOf(Ordning("3100")),
-            utbetalingsperioder = arrayListOf(maanedsutbetalingMock, maanedsutbetalingMock2),
-            aarsakIngenUtbetaling = emptyList(),
-            betingetTjenestepensjonErInkludert = false,
-            serviceData = emptyList()
-        )
-
-        return Result.success(klpResponseMock)
-    }
-
-    private fun simulerv2(request: SimulerTjenestepensjonRequestDto, tpNummer: String): Result<SimulertTjenestepensjonMedMaanedsUtbetalinger> {
         return client.simuler(request, tpNummer)
             .fold(
                 onSuccess = {

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapperTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapperTest.kt
@@ -1,0 +1,83 @@
+package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp
+
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonFremtidigInntektDto
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.InkludertOrdning
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.KLPSimulerTjenestepensjonRequest
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.KLPSimulerTjenestepensjonResponse
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.Utbetaling
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class KLPMapperTest {
+
+    @Test
+    fun `map klp response`() {
+        val resp = KLPSimulerTjenestepensjonResponse(
+            listOf(InkludertOrdning("1000")),
+            listOf(
+                Utbetaling(LocalDate.of(2025, 2, 6), manedligUtbetaling = 1, arligUtbetaling = 12, ytelseType = "BTP"),
+                Utbetaling(LocalDate.of(2028, 3, 7), manedligUtbetaling = 2, arligUtbetaling = 24, ytelseType = "PAASLAG"),
+                Utbetaling(LocalDate.of(2030, 4, 8), manedligUtbetaling = 3, arligUtbetaling = 36, ytelseType = "OT6370"),
+            ),
+            listOf("SAERALDERSPAASLAG ikke støttet"), true
+        )
+
+        val result = KLPMapper.mapToResponse(resp)
+
+        assertEquals(1, result.ordningsListe.size)
+        assertEquals("1000", result.ordningsListe[0].tpNummer)
+        assertEquals(3, result.utbetalingsperioder.size)
+
+        assertEquals(resp.utbetalingsListe[0].fraOgMedDato, result.utbetalingsperioder[0].fom)
+        assertEquals(resp.utbetalingsListe[0].manedligUtbetaling, result.utbetalingsperioder[0].maanedligBelop)
+        assertEquals(resp.utbetalingsListe[0].ytelseType, result.utbetalingsperioder[0].ytelseType)
+        assertEquals(resp.utbetalingsListe[1].fraOgMedDato, result.utbetalingsperioder[1].fom)
+        assertEquals(resp.utbetalingsListe[1].manedligUtbetaling, result.utbetalingsperioder[1].maanedligBelop)
+        assertEquals(resp.utbetalingsListe[1].ytelseType, result.utbetalingsperioder[1].ytelseType)
+        assertEquals(resp.utbetalingsListe[2].fraOgMedDato, result.utbetalingsperioder[2].fom)
+        assertEquals(resp.utbetalingsListe[2].manedligUtbetaling, result.utbetalingsperioder[2].maanedligBelop)
+        assertEquals(resp.utbetalingsListe[2].ytelseType, result.utbetalingsperioder[2].ytelseType)
+
+        assertEquals(1, result.aarsakIngenUtbetaling.size)
+        assertEquals(resp.arsakIngenUtbetaling[0], result.aarsakIngenUtbetaling[0])
+
+    }
+
+    @Test
+    fun `map request to klp request`() {
+        val uttaksdato = LocalDate.of(2025, 2, 1)
+        val request = SimulerTjenestepensjonRequestDto(
+            pid = "12345678901",
+            sisteInntekt = 100000,
+            aarIUtlandetEtter16 = 3,
+            epsPensjon = true,
+            eps2G = true,
+            brukerBaOmAfp = true,
+            uttaksdato = uttaksdato,
+            foedselsdato = LocalDate.of(1990, 1, 1),
+            fremtidigeInntekter = listOf(
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2025, 2, 1), 4),
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2026, 3, 1), 5),
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2027, 4, 1), 6)
+            )
+        )
+
+        val result: KLPSimulerTjenestepensjonRequest = KLPMapper.mapToRequest(request)
+
+        assertEquals(request.pid, result.personId)
+        assertEquals(1, result.uttaksListe.size)
+        assertEquals("ALLE", result.uttaksListe[0].ytelseType)
+        assertEquals(uttaksdato, result.uttaksListe[0].fraOgMedDato)
+        assertEquals(request.fremtidigeInntekter!![0].aarligInntekt, result.fremtidigInntektsListe[0].arligInntekt)
+        assertEquals(request.fremtidigeInntekter!![0].fraOgMed, result.fremtidigInntektsListe[0].fraOgMedDato)
+        assertEquals(request.fremtidigeInntekter!![1].aarligInntekt, result.fremtidigInntektsListe[1].arligInntekt)
+        assertEquals(request.fremtidigeInntekter!![1].fraOgMed, result.fremtidigInntektsListe[1].fraOgMedDato)
+        assertEquals(request.fremtidigeInntekter!![2].aarligInntekt, result.fremtidigInntektsListe[2].arligInntekt)
+        assertEquals(request.fremtidigeInntekter!![2].fraOgMed, result.fremtidigInntektsListe[2].fraOgMedDato)
+        assertEquals(request.aarIUtlandetEtter16, result.arIUtlandetEtter16)
+        assertTrue(result.epsPensjon)
+        assertTrue(result.eps2G)
+    }
+}

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonClientTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonClientTest.kt
@@ -1,0 +1,167 @@
+package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import no.nav.tjenestepensjon.simulering.service.AADClient
+import no.nav.tjenestepensjon.simulering.testHelper.anyNonNull
+import no.nav.tjenestepensjon.simulering.v2.consumer.MaskinportenTokenClient
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjon
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TjenestepensjonSimuleringException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.TjenestepensjonV2025ServiceTest.Companion.dummyRequest
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.KLPMapper.PROVIDER_FULLT_NAVN
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.KLPTjenestepensjonClient.Companion.SIMULER_PATH
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.InkludertOrdning
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.KLPSimulerTjenestepensjonResponse
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.Utbetaling
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.util.ReflectionTestUtils.setField
+import java.time.LocalDate
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KLPTjenestepensjonClientTest {
+
+    @MockitoBean
+    private lateinit var aadClient: AADClient
+
+    @MockitoBean
+    private lateinit var maskinportenTokenClient: MaskinportenTokenClient
+
+    @Autowired
+    private lateinit var klpClient: KLPTjenestepensjonClient
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private var wireMockServer = WireMockServer().apply {
+        start()
+    }
+
+    @BeforeAll
+    fun beforeAll() {
+        Mockito.`when`(maskinportenTokenClient.pensjonsimuleringToken(anyNonNull())).thenReturn("bogustoken")
+    }
+
+    @AfterAll
+    fun afterAll() {
+        wireMockServer.stop()
+    }
+
+    @Test
+    fun `send request og les respons med tjenestepensjon fra klp`() {
+        setField(klpClient, "activeProfiles", "prod-gcp")
+        val tpNummer = "995566"
+        val mockResponse = klpSimulerTjenestepensjonResponse()
+        val stub = wireMockServer.stubFor(post(urlPathEqualTo("$SIMULER_PATH/$tpNummer")).willReturn(okJson(objectMapper.writeValueAsString(mockResponse))))
+
+        val response: Result<SimulertTjenestepensjon> = klpClient.simuler(dummyRequest("1963-02-05", brukerBaOmAfp = true), tpNummer)
+
+        assertTrue(response.isSuccess)
+        val tjenestepensjon = response.getOrNull()
+        assertNotNull(tjenestepensjon)
+        assertEquals(PROVIDER_FULLT_NAVN, tjenestepensjon!!.tpLeverandoer)
+        assertEquals(1, tjenestepensjon.ordningsListe.size)
+        assertEquals(tpNummer, tjenestepensjon.ordningsListe[0].tpNummer)
+        assertEquals(4, tjenestepensjon.utbetalingsperioder.size)
+        assertEquals(mockResponse.utbetalingsListe[0].fraOgMedDato, tjenestepensjon.utbetalingsperioder[0].fom)
+        assertEquals(mockResponse.utbetalingsListe[0].manedligUtbetaling, tjenestepensjon.utbetalingsperioder[0].maanedligBelop)
+        assertEquals(mockResponse.utbetalingsListe[0].ytelseType, tjenestepensjon.utbetalingsperioder[0].ytelseType)
+        assertEquals(mockResponse.utbetalingsListe[1].fraOgMedDato, tjenestepensjon.utbetalingsperioder[1].fom)
+        assertEquals(mockResponse.utbetalingsListe[1].manedligUtbetaling, tjenestepensjon.utbetalingsperioder[1].maanedligBelop)
+        assertEquals(mockResponse.utbetalingsListe[1].ytelseType, tjenestepensjon.utbetalingsperioder[1].ytelseType)
+        assertEquals(mockResponse.utbetalingsListe[2].fraOgMedDato, tjenestepensjon.utbetalingsperioder[2].fom)
+        assertEquals(mockResponse.utbetalingsListe[2].manedligUtbetaling, tjenestepensjon.utbetalingsperioder[2].maanedligBelop)
+        assertEquals(mockResponse.utbetalingsListe[2].ytelseType, tjenestepensjon.utbetalingsperioder[2].ytelseType)
+        assertEquals(mockResponse.utbetalingsListe[3].fraOgMedDato, tjenestepensjon.utbetalingsperioder[3].fom)
+        assertEquals(mockResponse.utbetalingsListe[3].manedligUtbetaling, tjenestepensjon.utbetalingsperioder[3].maanedligBelop)
+        assertEquals(mockResponse.utbetalingsListe[3].ytelseType, tjenestepensjon.utbetalingsperioder[3].ytelseType)
+        assertEquals(3, tjenestepensjon.aarsakIngenUtbetaling.size)
+        assertTrue(tjenestepensjon.aarsakIngenUtbetaling.containsAll(mockResponse.arsakIngenUtbetaling))
+
+        wireMockServer.removeStub(stub.uuid)
+    }
+
+    @Test
+    fun `send request og faa error fra klp`() {
+        val stub = wireMockServer.stubFor(post(urlPathEqualTo(SIMULER_PATH)).willReturn(serverError()))
+
+        val response: Result<SimulertTjenestepensjon> = klpClient.simuler(dummyRequest("1963-02-05", brukerBaOmAfp = true), "3100")
+        assertTrue(response.isFailure)
+        assertTrue(response.exceptionOrNull() is TjenestepensjonSimuleringException)
+
+        wireMockServer.removeStub(stub.uuid)
+    }
+
+    @Test
+    fun `ikke send request og returner mock i dev-gcp fra klp`() {
+        setField(klpClient, "activeProfiles", "dev-gcp")
+        val request = dummyRequest("1963-02-05", brukerBaOmAfp = true)
+        val tpNummer = "3100"
+
+        val mockExpectedResponse = KLPTjenestepensjonClient.provideMockResponse(request)
+
+        val stub = wireMockServer.stubFor(post(urlPathEqualTo("$SIMULER_PATH/$tpNummer")).willReturn(serverError()))
+
+        val response: Result<SimulertTjenestepensjon> = klpClient.simuler(request, tpNummer)
+
+        assertTrue(response.isSuccess)
+        val tjenestepensjon = response.getOrNull()
+        assertNotNull(tjenestepensjon)
+        assertEquals(PROVIDER_FULLT_NAVN, tjenestepensjon!!.tpLeverandoer)
+        assertEquals(1, tjenestepensjon.ordningsListe.size)
+        assertEquals(tpNummer, tjenestepensjon.ordningsListe[0].tpNummer)
+        assertEquals(3, tjenestepensjon.utbetalingsperioder.size)
+
+        assertEquals(mockExpectedResponse.utbetalingsListe[0].fraOgMedDato, tjenestepensjon.utbetalingsperioder[0].fom)
+        assertEquals(mockExpectedResponse.utbetalingsListe[0].manedligUtbetaling, tjenestepensjon.utbetalingsperioder[0].maanedligBelop)
+        assertEquals(mockExpectedResponse.utbetalingsListe[0].ytelseType, tjenestepensjon.utbetalingsperioder[0].ytelseType)
+        assertEquals(mockExpectedResponse.utbetalingsListe[1].fraOgMedDato, tjenestepensjon.utbetalingsperioder[1].fom)
+        assertEquals(mockExpectedResponse.utbetalingsListe[1].manedligUtbetaling, tjenestepensjon.utbetalingsperioder[1].maanedligBelop)
+        assertEquals(mockExpectedResponse.utbetalingsListe[1].ytelseType, tjenestepensjon.utbetalingsperioder[1].ytelseType)
+        assertEquals(mockExpectedResponse.utbetalingsListe[2].fraOgMedDato, tjenestepensjon.utbetalingsperioder[2].fom)
+        assertEquals(mockExpectedResponse.utbetalingsListe[2].manedligUtbetaling, tjenestepensjon.utbetalingsperioder[2].maanedligBelop)
+        assertEquals(mockExpectedResponse.utbetalingsListe[2].ytelseType, tjenestepensjon.utbetalingsperioder[2].ytelseType)
+        assertEquals(0, tjenestepensjon.aarsakIngenUtbetaling.size)
+
+        wireMockServer.removeStub(stub.uuid)
+    }
+
+    private fun klpSimulerTjenestepensjonResponse() = KLPSimulerTjenestepensjonResponse(
+        inkludertOrdningListe = listOf(InkludertOrdning("995566")),
+        utbetalingsListe = listOf(
+            Utbetaling(
+                fraOgMedDato = LocalDate.parse("2025-03-01"),
+                manedligUtbetaling = 1,
+                arligUtbetaling = 12,
+                ytelseType = "OAFP",
+            ),
+            Utbetaling(
+                fraOgMedDato = LocalDate.parse("2025-03-01"),
+                manedligUtbetaling = 2,
+                arligUtbetaling = 24,
+                ytelseType = "PAASLAG",
+            ),
+            Utbetaling(
+                fraOgMedDato = LocalDate.parse("2025-03-01"),
+                manedligUtbetaling = 3,
+                arligUtbetaling = 36,
+                ytelseType = "APOF2020",
+            ),
+            Utbetaling(
+                fraOgMedDato = LocalDate.parse("2025-03-01"),
+                manedligUtbetaling = 4,
+                arligUtbetaling = 48,
+                ytelseType = "OT6370",
+            )
+        ),
+        arsakIngenUtbetaling = listOf("IKKE_STOETTET", "Ikke stoettet", "SAERALDERSPAASLAG"),
+        betingetTjenestepensjonErInkludert = false,
+    )
+
+}

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonServiceTest.kt
@@ -9,13 +9,11 @@ import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Utbetal
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpOrdningStoettesIkkeException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.TjenestepensjonV2025ServiceTest.Companion.dummyRequest
 import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.bean.override.mockito.MockitoBean
-import org.springframework.test.util.ReflectionTestUtils.setField
 import java.time.LocalDate
 import kotlin.test.assertEquals
 
@@ -30,11 +28,6 @@ class KLPTjenestepensjonServiceTest {
 
     @MockitoBean
     private lateinit var client: KLPTjenestepensjonClient
-
-    @BeforeEach
-    fun initialize() {
-        setField(klpTjenestepensjonService, "activeProfiles", "prod-gcp")
-    }
 
     @Test
     fun `simulering skal ikke skje naar feature toggle er av`() {

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonClientTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonClientTest.kt
@@ -63,7 +63,7 @@ class SPKTjenestepensjonClientTest{
         assertNotNull(tjenestepensjon)
         assertEquals(PROVIDER_FULLT_NAVN, tjenestepensjon!!.tpLeverandoer)
         assertEquals(1, tjenestepensjon.ordningsListe.size)
-        assertEquals("3010", tjenestepensjon.ordningsListe[0].tpNummer)
+        assertEquals(tpNummer, tjenestepensjon.ordningsListe[0].tpNummer)
         assertEquals(5, tjenestepensjon.utbetalingsperioder.size)
         assertEquals(mockResponse.utbetalingListe[0].fraOgMedDato, tjenestepensjon.utbetalingsperioder[0].fom)
         assertEquals(mockResponse.utbetalingListe[0].delytelseListe[0].maanedligBelop, tjenestepensjon.utbetalingsperioder[0].maanedligBelop)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -64,7 +64,7 @@ oftp:
   2025:
     klp:
       endpoint:
-        url: https://api-test.klp.no
+        url: http://localhost:8080
         maskinportenscope: klp:oftp/simulering
     spk:
       endpoint:


### PR DESCRIPTION
- Flytte mockede KLP-data til klp-client for å avdekke mulige feil i mapping og filtrering som skjer rett etter henting av tjenestepensjon fra KLP.
- Skrive manglende tester