### PR TITLE
PEK-1053 base images er frarådet til å bruke. bruk distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,6 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
+FROM gcr.io/distroless/java21-debian12:nonroot
+WORKDIR /app
+ENV TZ="Europe/Oslo"
 COPY build/libs/tjenestepensjon-simulering.jar app.jar
+EXPOSE 8080
+CMD ["app.jar"]


### PR DESCRIPTION
Bytter docker-image til "distroless" først for å fjerne sårbarhet fra
[https://ubuntu.com/security/CVE-2024-38428](https://ubuntu.com/security/CVE-2024-38428)
