### PR TITLE
PEK-1093 Fetch delingstall from pensjon-regler

### DIFF
--- a/.nais/nais-dev-gcp.yaml
+++ b/.nais/nais-dev-gcp.yaml
@@ -61,15 +61,11 @@ spec:
           cluster: dev-fss
         - application: pensjon-opptjening-afp-api
           namespace: pensjonopptjening
-        - application: pensjon-pen-q2
-          namespace: pensjon-q2
-          cluster: dev-fss
         - application: pensjon-selvbetjening-fss-gateway
           namespace: pensjonselvbetjening
           cluster: dev-fss
       external:
         - host: pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
-        - host: pensjon-pen-q2.dev-fss-pub.nais.io
         - host: tp-api-q2.dev-fss-pub.nais.io
         - host: api.preprod.spk.no
         - host: api.test.spk.no
@@ -113,10 +109,6 @@ spec:
       value: http://pensjon-opptjening-afp-api.pensjonopptjening
     - name: afp_beholdning_scope
       value: api://dev-gcp.pensjonopptjening.pensjon-opptjening-afp-api/.default
-    - name: pen_url
-      value: https://pensjon-pen-q2.dev-fss-pub.nais.io/pen/springapi
-    - name: pen_scope
-      value: api://dev-fss.pensjon-q2.pensjon-pen-q2/.default
     - name: pen_fss_gateway_url
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
     - name: pen_fss_gateway_scope

--- a/.nais/nais-dev-gcp.yaml
+++ b/.nais/nais-dev-gcp.yaml
@@ -61,10 +61,14 @@ spec:
           cluster: dev-fss
         - application: pensjon-opptjening-afp-api
           namespace: pensjonopptjening
+        - application: pensjon-regler-q2
+          namespace: pensjon-regler
+          cluster: dev-fss
         - application: pensjon-selvbetjening-fss-gateway
           namespace: pensjonselvbetjening
           cluster: dev-fss
       external:
+        - host: pensjon-regler-q2.dev-fss-pub.nais.io
         - host: pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
         - host: tp-api-q2.dev-fss-pub.nais.io
         - host: api.preprod.spk.no
@@ -101,6 +105,8 @@ spec:
       value: dev-gcp
     - name: provider_uri
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io/ekstern-pensjon-tjeneste-tjenestepensjonSimuleringWeb/sca/TjenestepensjonSimuleringWSEXP
+    - name: regler_url
+      value: https://pensjon-regler-q2.dev-fss-pub.nais.io
     - name: tp_url
       value: https://tp-api-q2.dev-fss-pub.nais.io
     - name: tp_scope

--- a/.nais/nais-prod-gcp.yaml
+++ b/.nais/nais-prod-gcp.yaml
@@ -39,13 +39,9 @@ spec:
           cluster: prod-fss
         - application: pensjon-opptjening-afp-api
           namespace: pensjonopptjening
-        - application: pensjon-pen
-          namespace: pensjondeployer
-          cluster: prod-fss
       external:
         - host: pensjon-selvbetjening-fss-gateway.prod-fss-pub.nais.io
         - host: pensjonskalkulator-unleash-api.nav.cloud.nais.io
-        - host: pensjon-pen.prod-fss-pub.nais.io
         - host: tp-api.prod-fss-pub.nais.io
         - host: api.prod.spk.no
         - host: api.klp.no
@@ -87,10 +83,6 @@ spec:
       value: http://pensjon-opptjening-afp-api.pensjonopptjening
     - name: afp_beholdning_scope
       value: api://prod-gcp.pensjonopptjening.pensjon-opptjening-afp-api/.default
-    - name: pen_url
-      value: https://pensjon-pen.prod-fss-pub.nais.io/pen/springapi
-    - name: pen_scope
-      value: api://prod-fss.pensjondeployer.pensjon-pen/.default
     - name: pen_fss_gateway_url
       value: https://pensjon-selvbetjening-fss-gateway.prod-fss-pub.nais.io
     - name: pen_fss_gateway_scope

--- a/.nais/nais-prod-gcp.yaml
+++ b/.nais/nais-prod-gcp.yaml
@@ -39,7 +39,11 @@ spec:
           cluster: prod-fss
         - application: pensjon-opptjening-afp-api
           namespace: pensjonopptjening
+        - application: pensjon-regler
+          namespace: pensjon-regler
+          cluster: prod-fss
       external:
+        - host: pensjon-regler.prod-fss-pub.nais.io
         - host: pensjon-selvbetjening-fss-gateway.prod-fss-pub.nais.io
         - host: pensjonskalkulator-unleash-api.nav.cloud.nais.io
         - host: tp-api.prod-fss-pub.nais.io
@@ -75,6 +79,8 @@ spec:
       value: prod-gcp
     - name: provider_uri
       value: https://pensjon-selvbetjening-fss-gateway.prod-fss-pub.nais.io/ekstern-pensjon-tjeneste-tjenestepensjonSimuleringWeb/sca/TjenestepensjonSimuleringWSEXP
+    - name: regler_url
+      value: https://pensjon-regler.prod-fss-pub.nais.io
     - name: tp_url
       value: https://tp-api.prod-fss-pub.nais.io
     - name: tp_scope

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
@@ -110,9 +110,9 @@ class WebClientConfig {
         .build()
 
     @Bean
-    fun penWebClient(
-        @Value("\${pen.url}") baseUrl: String,
-        @Value("\${pen.scope}") scope: String,
+    fun reglerWebClient(
+        @Value("\${pen.fss.gateway.url}") baseUrl: String,
+        @Value("\${pen.fss.gateway.scope}") scope: String,
         builder: WebClient.Builder,
         httpClient: HttpClient,
         adClient: AADClient,

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
@@ -111,18 +111,15 @@ class WebClientConfig {
 
     @Bean
     fun reglerWebClient(
-        @Value("\${pen.fss.gateway.url}") baseUrl: String,
-        @Value("\${pen.fss.gateway.scope}") scope: String,
+        @Value("\${regler.url}") baseUrl: String,
         builder: WebClient.Builder,
         httpClient: HttpClient,
-        adClient: AADClient,
     ): WebClient = builder
         .baseUrl(baseUrl)
         .clientConnector(ReactorClientHttpConnector(httpClient))
         .filter { request, next ->
             next.exchange(
                 ClientRequest.from(request)
-                    .headers { it.setBearerAuth(adClient.getToken(scope)) }
                     .build()
             )
         }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/ReglerClient.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/service/ReglerClient.kt
@@ -10,20 +10,21 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.util.retry.Retry
+import java.time.Duration
 
 @Service
-class PenClient(val penWebClient: WebClient) {
+class ReglerClient(val reglerWebClient: WebClient) {
     private val log = KotlinLogging.logger {}
     fun hentDelingstall(aarskull: Int, alder: List<Alder>): List<Delingstall> {
         return try {
-            penWebClient.post()
-                .uri("/delingstall")
+            reglerWebClient.post()
+                .uri("/api/delingstall")
                 .bodyValue(HentDelingstallRequest(aarskull, alder))
                 .retrieve()
                 .bodyToMono(HentDelingstallResponse::class.java)
                 .retryWhen(
-                    Retry.backoff(3, java.time.Duration.ofSeconds(1))
-                        .maxBackoff(java.time.Duration.ofSeconds(10))
+                    Retry.backoff(3, Duration.ofSeconds(1))
+                        .maxBackoff(Duration.ofSeconds(10))
                         .jitter(0.2) // 20% tilfeldig forsinkelse
                         .doBeforeRetry { retrySignal ->
                             log.warn { "Retrying henting av delingstall due to: ${retrySignal.failure().message}, attempt: ${retrySignal.totalRetries() + 1}" }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,9 +16,8 @@ afp:
   beholdning:
     url: https://pensjon-opptjening-afp-api.intern.dev.nav.no
     scope: api://dev-gcp.pensjonopptjening.pensjon-opptjening-afp-api/.default
-pen:
-  url: https://pensjon-pen-q2.dev.adeo.no/pen/springapi
-  scope: api://dev-fss.pensjon-q2.pensjon-pen-q2/.default
+regler:
+  url: https://pensjon-regler-q2.dev.intern.nav.no
 logging:
   level:
     no:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,8 +41,6 @@ afp:
     url: http://localhost:8080
     scope: api://bogus
 pen:
-  url: http://localhost:8080
-  scope: api://bogus
   fss:
     gateway:
       url: http://localhost:8080
@@ -63,6 +61,8 @@ oftp:
         url: https://api.prod.spk.no
         maskinportenscope: spk:nav
         stillingsprosentUrl: https://partner-gw.spk.no:443/nav/SimulereTjenestepensjon
+regler:
+  url: http://localhost:8080
 unleash:
   server:
     api:

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/afp/v1/AFPOffentligLivsvarigSimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/afp/v1/AFPOffentligLivsvarigSimuleringServiceTest.kt
@@ -5,7 +5,7 @@ import no.nav.tjenestepensjon.simulering.model.domain.pen.Delingstall
 import no.nav.tjenestepensjon.simulering.model.domain.pen.SimulerAFPOffentligLivsvarigRequest
 import no.nav.tjenestepensjon.simulering.model.domain.popp.AFPGrunnlagBeholdningPeriode
 import no.nav.tjenestepensjon.simulering.service.AFPBeholdningClient
-import no.nav.tjenestepensjon.simulering.service.PenClient
+import no.nav.tjenestepensjon.simulering.service.ReglerClient
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -25,7 +25,7 @@ class AFPOffentligLivsvarigSimuleringServiceTest {
         val alderVedAarsskifte = Alder(62, 1)
 
         val afpBeholdningClient = mock<AFPBeholdningClient>{ on { simulerAFPBeholdningGrunnlag(any()) }.thenReturn(afpBeholdningGrunnlagResponse) }
-        val delingstallClient = mock<PenClient> { on { hentDelingstall(any(), any()) }.thenReturn(listOf(Delingstall(lavesteAlderVedUttak, 20.37), Delingstall(alderVedAarsskifte, 20.31))) }
+        val delingstallClient = mock<ReglerClient> { on { hentDelingstall(any(), any()) }.thenReturn(listOf(Delingstall(lavesteAlderVedUttak, 20.37), Delingstall(alderVedAarsskifte, 20.31))) }
         val service = AFPOffentligLivsvarigSimuleringService(afpBeholdningClient, delingstallClient)
 
         val resultat = service.simuler(SimulerAFPOffentligLivsvarigRequest("07516443469", fodselsdato, listOf(), LocalDate.of(2026, 12, 1)))

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -38,8 +38,6 @@ afp:
     url: http://localhost:8080
     scope: api://bogus
 pen:
-  url: http://localhost:8080
-  scope: api://bogus
   fss:
     gateway:
       url: http://localhost:8080
@@ -60,6 +58,8 @@ oftp:
         url: http://localhost:8080
         maskinportenscope: spk:nav
         stillingsprosentUrl: http://opptjening.com
+regler:
+  url: http://localhost:8080
 unleash:
   server:
     api:


### PR DESCRIPTION
Delingstall skal hentes fra pensjon-regler istedenfor PEN (ref. [Slack 2025-03-03](https://nav-it.slack.com/archives/C04M46SPSRL/p1741005330230589)).

Relatert commit i FSS-gateway: [bd1f5d5](https://github.com/navikt/pensjon-selvbetjening-fss-gateway/commit/bd1f5d59ecef6e6cbb5a2a45777d8e1f97a1090c).