### PR TITLE
Feature/pek 1114 ta hensyn til returkode

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025Controller.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/rest/TjenestepensjonSimuleringV2025Controller.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import java.lang.RuntimeException
 
 @RestController
 class TjenestepensjonSimuleringV2025Controller(
@@ -39,6 +38,7 @@ class TjenestepensjonSimuleringV2025Controller(
                     is TpOrdningStoettesIkkeException -> SimulerTjenestepensjonResponseDto(ResultatTypeDto.TP_ORDNING_ER_IKKE_STOTTET, e.message, relevanteTpOrdninger)
                     is TjenestepensjonSimuleringException -> SimulerTjenestepensjonResponseDto(ResultatTypeDto.TEKNISK_FEIL_FRA_TP_ORDNING, e.message, relevanteTpOrdninger)
                     is TomSimuleringFraTpOrdningException -> SimulerTjenestepensjonResponseDto(ResultatTypeDto.INGEN_UTBETALINGSPERIODER_FRA_TP_ORDNING, "Simulering fra ${e.tpOrdning} inneholder ingen utbetalingsperioder", relevanteTpOrdninger)
+                    is IkkeSisteOrdningException -> SimulerTjenestepensjonResponseDto(ResultatTypeDto.INGEN_UTBETALINGSPERIODER_FRA_TP_ORDNING, "Simulering fra ${e.tpOrdning} inneholder ingen utbetalingsperioder", relevanteTpOrdninger)
                     is TpregisteretException -> loggOgReturnerTekniskFeil(e)
                     else -> loggOgReturnerTekniskFeil(RuntimeException(e))
                 }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/domain/SimulertTjenestepensjon.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/domain/SimulertTjenestepensjon.kt
@@ -7,6 +7,7 @@ open class SimulertTjenestepensjon(
     var aarsakIngenUtbetaling: List<String> = emptyList(),
     val betingetTjenestepensjonErInkludert: Boolean,
     var serviceData: List<String> = emptyList(),
+    var erSisteOrdning: Boolean = false,
 ){
     override fun toString(): String {
         return "(tpLeverandoer='$tpLeverandoer', ordningsListe=$ordningsListe, utbetalingsperioder=$utbetalingsperioder, aarsakIngenUtbetaling=$aarsakIngenUtbetaling, betingetTjenestepensjonErInkludert=$betingetTjenestepensjonErInkludert"

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/exception/IkkeSisteOrdningException.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/exception/IkkeSisteOrdningException.kt
@@ -1,0 +1,6 @@
+package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception
+
+class IkkeSisteOrdningException(val tpOrdning: String) : RuntimeException()  {
+        override val message: String
+            get() = "$tpOrdning er ikke siste ordning"
+}

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
@@ -5,7 +5,10 @@ import no.nav.tjenestepensjon.simulering.ping.PingResponse
 import no.nav.tjenestepensjon.simulering.service.TpClient
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.*
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.BrukerErIkkeMedlemException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TomSimuleringFraTpOrdningException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpOrdningStoettesIkkeException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpregisteretException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.KLPTjenestepensjonService
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk.SPKTjenestepensjonService
 import org.springframework.stereotype.Service
@@ -45,7 +48,7 @@ class TjenestepensjonV2025Service(
                 else -> Result.failure(TpOrdningStoettesIkkeException(ordning))
             }.run {
                 onSuccess { return tpOrdningerNavn to this }
-                onFailure { if (it !is IkkeSisteOrdningException) return tpOrdningerNavn to this }
+                onFailure { if (it is TomSimuleringFraTpOrdningException) return tpOrdningerNavn to this } //Skjer kun hvis siste ordning
             }
         }
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
@@ -5,10 +5,7 @@ import no.nav.tjenestepensjon.simulering.ping.PingResponse
 import no.nav.tjenestepensjon.simulering.service.TpClient
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.BrukerErIkkeMedlemException
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TomSimuleringFraTpOrdningException
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpOrdningStoettesIkkeException
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpregisteretException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.*
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.KLPTjenestepensjonService
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk.SPKTjenestepensjonService
 import org.springframework.stereotype.Service
@@ -48,6 +45,7 @@ class TjenestepensjonV2025Service(
                 else -> Result.failure(TpOrdningStoettesIkkeException(ordning))
             }.run {
                 onSuccess { return tpOrdningerNavn to this }
+                onFailure { if (it !is IkkeSisteOrdningException) return tpOrdningerNavn to this }
             }
         }
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
@@ -5,10 +5,7 @@ import no.nav.tjenestepensjon.simulering.ping.PingResponse
 import no.nav.tjenestepensjon.simulering.service.TpClient
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.BrukerErIkkeMedlemException
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TomSimuleringFraTpOrdningException
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpOrdningStoettesIkkeException
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TpregisteretException
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.*
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.KLPTjenestepensjonService
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk.SPKTjenestepensjonService
 import org.springframework.stereotype.Service
@@ -55,7 +52,7 @@ class TjenestepensjonV2025Service(
         // Returnerer først tekniske feil hvis funnet
         simulertTpListe.forEach { simulering ->
             simulering.onFailure {
-                if (it !is TpOrdningStoettesIkkeException && it !is TomSimuleringFraTpOrdningException) return tpOrdningerNavn to simulering
+                if (it !is IkkeSisteOrdningException && it !is TpOrdningStoettesIkkeException && it !is TomSimuleringFraTpOrdningException) return tpOrdningerNavn to simulering
             }
         }
 

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
@@ -1,5 +1,6 @@
 package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Ordning
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjon
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Utbetalingsperiode
@@ -10,6 +11,7 @@ import java.time.LocalDate
 
 object KLPMapper {
 
+    private val log = KotlinLogging.logger {}
     const val PROVIDER_FULLT_NAVN = "Kommunal Landspensjonskasse"
 
     fun mapToRequest(request: SimulerTjenestepensjonRequestDto) =
@@ -46,8 +48,9 @@ object KLPMapper {
 
     private fun aarUtenRegistrertInntektHosSkatteetaten(): LocalDate = LocalDate.now().minusYears(2).withDayOfYear(1)
 
-    fun mapToResponse(response: KLPSimulerTjenestepensjonResponse, dto: LoggableSimulerTjenestepensjonRequestDto? = null) =
-        SimulertTjenestepensjon(
+    fun mapToResponse(response: KLPSimulerTjenestepensjonResponse, dto: LoggableSimulerTjenestepensjonRequestDto? = null) : SimulertTjenestepensjon {
+        log.info { "Mapping response from KLP $response" }
+        return SimulertTjenestepensjon(
             tpLeverandoer = PROVIDER_FULLT_NAVN,
             ordningsListe = response.inkludertOrdningListe.map { Ordning(it.tpnr) },
             utbetalingsperioder = response.utbetalingsListe.map { Utbetalingsperiode(it.fraOgMedDato, it.manedligUtbetaling, it.ytelseType) },
@@ -56,6 +59,7 @@ object KLPMapper {
         ).apply {
             serviceData = listOf("Request: ${dto?.toString()}","Response: $response")
         }
+    }
 
 
 }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
@@ -54,7 +54,7 @@ object KLPMapper {
             tpLeverandoer = PROVIDER_FULLT_NAVN,
             ordningsListe = response.inkludertOrdningListe.map { Ordning(it.tpnr) },
             utbetalingsperioder = response.utbetalingsListe.map { Utbetalingsperiode(it.fraOgMedDato, it.manedligUtbetaling, it.ytelseType) },
-            aarsakIngenUtbetaling = response.arsakIngenUtbetaling,
+            aarsakIngenUtbetaling = response.arsakIngenUtbetaling.map { it.statusBeskrivelse + ": " + it.ytelseType },
             betingetTjenestepensjonErInkludert = response.utbetalingsListe.any { it.ytelseType == KLPYtelse.BTP.name }
         ).apply {
             serviceData = listOf("Request: ${dto?.toString()}","Response: $response")

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
@@ -49,7 +49,7 @@ object KLPMapper {
     private fun aarUtenRegistrertInntektHosSkatteetaten(): LocalDate = LocalDate.now().minusYears(2).withDayOfYear(1)
 
     fun mapToResponse(response: KLPSimulerTjenestepensjonResponse, dto: LoggableSimulerTjenestepensjonRequestDto? = null) : SimulertTjenestepensjon {
-        log.info { "Mapping response from KLP $response" }
+        log.debug { "Mapping response from KLP $response" }
         return SimulertTjenestepensjon(
             tpLeverandoer = PROVIDER_FULLT_NAVN,
             ordningsListe = response.inkludertOrdningListe.map { Ordning(it.tpnr) },

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/dto/KLPSimulerTjenestepensjonResponse.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/dto/KLPSimulerTjenestepensjonResponse.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 data class KLPSimulerTjenestepensjonResponse(
     val inkludertOrdningListe: List<InkludertOrdning>,
     val utbetalingsListe: List<Utbetaling>,
-    val arsakIngenUtbetaling: List<String>,
+    val arsakIngenUtbetaling: List<ArsakIngenUtbetaling>,
     val betingetTjenestepensjonErInkludert: Boolean,
 )
 
@@ -18,4 +18,10 @@ data class Utbetaling(
     val manedligUtbetaling: Int,
     val arligUtbetaling: Int,
     val ytelseType: String
+)
+
+data class ArsakIngenUtbetaling(
+    val statusKode: String,
+    val statusBeskrivelse: String,
+    val ytelseType: String,
 )

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapper.kt
@@ -60,7 +60,7 @@ object SPKMapper {
     private fun fjorAarSomManglerOpptjeningIPopp(): LocalDate = LocalDate.now().minusYears(1).withDayOfYear(1)
 
     fun mapToResponse(response: SPKSimulerTjenestepensjonResponse, dto: SPKSimulerTjenestepensjonRequest? = null): SimulertTjenestepensjon {
-        log.info { "Mapping response from SPK $response" }
+        log.debug { "Mapping response from SPK $response" }
         return SimulertTjenestepensjon(
             tpLeverandoer = PROVIDER_FULLT_NAVN,
             ordningsListe = response.inkludertOrdningListe.map { Ordning(it.tpnr) },
@@ -70,6 +70,7 @@ object SPKMapper {
             },
             aarsakIngenUtbetaling = response.aarsakIngenUtbetaling.map { it.statusBeskrivelse + ": " + it.ytelseType },
             betingetTjenestepensjonErInkludert = response.utbetalingListe.flatMap { it.delytelseListe }.any { it.ytelseType == "BTP" },
+            erSisteOrdning = response.aarsakIngenUtbetaling.none { it.statusKode == "IKKE_SISTE_ORDNING" },
             serviceData = listOf("Request: " + dto?.toString(), "Response: $response")
         )
     }

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapper.kt
@@ -60,7 +60,7 @@ object SPKMapper {
     private fun fjorAarSomManglerOpptjeningIPopp(): LocalDate = LocalDate.now().minusYears(1).withDayOfYear(1)
 
     fun mapToResponse(response: SPKSimulerTjenestepensjonResponse, dto: SPKSimulerTjenestepensjonRequest? = null): SimulertTjenestepensjon {
-        log.debug { "Mapping response from SPK $response" }
+        log.info { "Mapping response from SPK $response" }
         return SimulertTjenestepensjon(
             tpLeverandoer = PROVIDER_FULLT_NAVN,
             ordningsListe = response.inkludertOrdningListe.map { Ordning(it.tpnr) },

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
@@ -26,7 +26,7 @@ class SPKTjenestepensjonService(private val client: SPKTjenestepensjonClient, pr
         return client.simuler(request, tpNummer)
             .fold(
                 onSuccess = {
-                    if (it.utbetalingsperioder.isEmpty())
+                    if (!it.erSisteOrdning)
                         Result.failure(TomSimuleringFraTpOrdningException(TP_ORDNING))
                     else
                         Result.success(

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonService.kt
@@ -7,6 +7,7 @@ import no.nav.tjenestepensjon.simulering.service.FeatureToggleService.Companion.
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.SimulertTjenestepensjonMedMaanedsUtbetalinger
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.domain.Utbetalingsperiode
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.IkkeSisteOrdningException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TjenestepensjonSimuleringException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.exception.TomSimuleringFraTpOrdningException
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.TpUtil
@@ -27,6 +28,8 @@ class SPKTjenestepensjonService(private val client: SPKTjenestepensjonClient, pr
             .fold(
                 onSuccess = {
                     if (!it.erSisteOrdning)
+                        Result.failure(IkkeSisteOrdningException(TP_ORDNING))
+                    else if (it.utbetalingsperioder.isEmpty())
                         Result.failure(TomSimuleringFraTpOrdningException(TP_ORDNING))
                     else
                         Result.success(

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapperTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapperTest.kt
@@ -2,11 +2,9 @@ package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp
 
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonFremtidigInntektDto
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.InkludertOrdning
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.KLPSimulerTjenestepensjonRequest
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.KLPSimulerTjenestepensjonResponse
-import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.Utbetaling
-import org.junit.jupiter.api.Assertions.*
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -21,7 +19,7 @@ class KLPMapperTest {
                 Utbetaling(LocalDate.of(2028, 3, 7), manedligUtbetaling = 2, arligUtbetaling = 24, ytelseType = "PAASLAG"),
                 Utbetaling(LocalDate.of(2030, 4, 8), manedligUtbetaling = 3, arligUtbetaling = 36, ytelseType = "OT6370"),
             ),
-            listOf("SAERALDERSPAASLAG ikke støttet"), true
+            listOf(ArsakIngenUtbetaling(statusKode = "IKKE_STOETTET", statusBeskrivelse = "Ikke stoettet", ytelseType = "SAERALDERSPAASLAG")), true
         )
 
         val result = KLPMapper.mapToResponse(resp)
@@ -41,7 +39,7 @@ class KLPMapperTest {
         assertEquals(resp.utbetalingsListe[2].ytelseType, result.utbetalingsperioder[2].ytelseType)
 
         assertEquals(1, result.aarsakIngenUtbetaling.size)
-        assertEquals(resp.arsakIngenUtbetaling[0], result.aarsakIngenUtbetaling[0])
+        assertEquals("Ikke stoettet: SAERALDERSPAASLAG", result.aarsakIngenUtbetaling.first())
 
     }
 

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonClientTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPTjenestepensjonClientTest.kt
@@ -12,6 +12,7 @@ import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.Sammen
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.TjenestepensjonV2025ServiceTest.Companion.dummyRequest
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.KLPMapper.PROVIDER_FULLT_NAVN
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.KLPTjenestepensjonClient.Companion.SIMULER_PATH
+import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.ArsakIngenUtbetaling
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.InkludertOrdning
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.KLPSimulerTjenestepensjonResponse
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.klp.dto.Utbetaling
@@ -89,8 +90,8 @@ class KLPTjenestepensjonClientTest {
         assertEquals(mockResponse.utbetalingsListe[3].fraOgMedDato, tjenestepensjon.utbetalingsperioder[3].fom)
         assertEquals(mockResponse.utbetalingsListe[3].manedligUtbetaling, tjenestepensjon.utbetalingsperioder[3].maanedligBelop)
         assertEquals(mockResponse.utbetalingsListe[3].ytelseType, tjenestepensjon.utbetalingsperioder[3].ytelseType)
-        assertEquals(3, tjenestepensjon.aarsakIngenUtbetaling.size)
-        assertTrue(tjenestepensjon.aarsakIngenUtbetaling.containsAll(mockResponse.arsakIngenUtbetaling))
+        assertEquals(1, tjenestepensjon.aarsakIngenUtbetaling.size)
+        assertTrue(tjenestepensjon.aarsakIngenUtbetaling.first().contains(mockResponse.arsakIngenUtbetaling.first().ytelseType))
 
         wireMockServer.removeStub(stub.uuid)
     }
@@ -168,7 +169,7 @@ class KLPTjenestepensjonClientTest {
                 ytelseType = "OT6370",
             )
         ),
-        arsakIngenUtbetaling = listOf("IKKE_STOETTET", "Ikke stoettet", "SAERALDERSPAASLAG"),
+        arsakIngenUtbetaling = listOf(ArsakIngenUtbetaling( "IKKE_STOETTET", "Ikke stoettet", "SAERALDERSPAASLAG")),
         betingetTjenestepensjonErInkludert = false,
     )
 

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapperTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapperTest.kt
@@ -3,9 +3,8 @@ package no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonFremtidigInntektDto
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.dto.request.SimulerTjenestepensjonRequestDto
 import no.nav.tjenestepensjon.simulering.v2025.tjenestepensjon.v1.service.spk.dto.*
-import org.junit.jupiter.api.Test
-
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class SPKMapperTest {
@@ -149,6 +148,39 @@ class SPKMapperTest {
         assertEquals(LocalDate.of(2026, 3, 1), result.fremtidigInntektListe[2].fraOgMedDato)
         assertEquals(6, result.fremtidigInntektListe[3].aarligInntekt)
         assertEquals(LocalDate.of(2027, 4, 1), result.fremtidigInntektListe[3].fraOgMedDato)
+
+    }
+
+    @Test
+    fun `map response som er siste ordning`() {
+        val resp = SPKSimulerTjenestepensjonResponse(
+            listOf(InkludertOrdning("3010")),
+            listOf(
+                Utbetaling(LocalDate.of(2025, 2, 1), listOf(Delytelse("BTP", 141), Delytelse("PAASLAG", 268))),
+                Utbetaling(LocalDate.of(2030, 2, 1), listOf(Delytelse("OT6370", 779), Delytelse("PAASLAG", 268)))
+            ),
+            listOf(AarsakIngenUtbetaling("IKKE_STOETTET", "Ikke stoettet", "SAERALDERSPAASLAG"))
+        )
+
+        val result = SPKMapper.mapToResponse(resp)
+
+        assertTrue(result.erSisteOrdning)
+    }
+
+    @Test
+    fun `map response som ikke er siste ordning`() {
+        val resp = SPKSimulerTjenestepensjonResponse(
+            listOf(InkludertOrdning("3010")),
+            listOf(
+                Utbetaling(LocalDate.of(2025, 2, 1), listOf(Delytelse("BTP", 141), Delytelse("PAASLAG", 268))),
+                Utbetaling(LocalDate.of(2030, 2, 1), listOf(Delytelse("OT6370", 779), Delytelse("PAASLAG", 268)))
+            ),
+            listOf(AarsakIngenUtbetaling("IKKE_SISTE_ORDNING", "Ikke siste ordning", ""))
+        )
+
+        val result = SPKMapper.mapToResponse(resp)
+
+        assertFalse(result.erSisteOrdning)
 
     }
 }

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKTjenestepensjonServiceTest.kt
@@ -83,7 +83,8 @@ class SPKTjenestepensjonServiceTest {
                     ytelseType = "OAFP"
                 ),
             ),
-            betingetTjenestepensjonErInkludert = false
+            betingetTjenestepensjonErInkludert = false,
+            erSisteOrdning = true
         )))
 
         val res : Result<SimulertTjenestepensjonMedMaanedsUtbetalinger> = spkTjenestepensjonService.simuler(req,"3010")
@@ -112,6 +113,28 @@ class SPKTjenestepensjonServiceTest {
         assertTrue(tjenestepensjonException!!.message!!.contains("Simulering av tjenestepensjon hos SPK er slått av"))
     }
 
+    @Test
+    fun `result skal vaere failure hvis ikke siste ordning`() {
+        val req = dummyRequest("1963-02-05")
+        `when`(client.simuler(req,"3010")).thenReturn(Result.success(SimulertTjenestepensjon(
+            tpLeverandoer = "spk",
+            ordningsListe = listOf(Ordning("3010")),
+            utbetalingsperioder = listOf(
+                Utbetalingsperiode(
+                    fom = LocalDate.parse("2026-03-01"),
+                    maanedligBelop = 3000,
+                    ytelseType = "SAERALDERSPAASLAG"
+                ),
+            ),
+            betingetTjenestepensjonErInkludert = false,
+            erSisteOrdning = false
+        )))
+
+        val res: Result<SimulertTjenestepensjonMedMaanedsUtbetalinger> = spkTjenestepensjonService.simuler(req,"3010")
+
+        assertTrue(res.isFailure)
+    }
+
     fun dummyResult(inkluderBTP: Boolean = false) : Result<SimulertTjenestepensjon> {
         return Result.success(SimulertTjenestepensjon(
             tpLeverandoer = "spk",
@@ -138,7 +161,8 @@ class SPKTjenestepensjonServiceTest {
                     ytelseType = "APOF2020"
                 ),
             ),
-            betingetTjenestepensjonErInkludert = inkluderBTP
+            betingetTjenestepensjonErInkludert = inkluderBTP,
+            erSisteOrdning = true
         ))
     }
 


### PR DESCRIPTION
Tar nå hensyn til statuskode "IKKE_SISTE_ORDNING", og kaller kun neste tp ordning dersom denne blir sendt med.
(For nå kun implementert hos SPK siden KLP ser ikke ut til å sende denne enda. Har uansett ingenting å si siden vi kaller KLP sist)