### PR TITLE
Fiks for feil delingstall ved beregning av offentlig AFP

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/afp/v1/AlderForDelingstallBeregner.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/afp/v1/AlderForDelingstallBeregner.kt
@@ -4,13 +4,13 @@ import no.nav.tjenestepensjon.simulering.common.AlderUtil.bestemAlderVedDato
 import no.nav.tjenestepensjon.simulering.model.domain.pen.Alder
 import no.nav.tjenestepensjon.simulering.model.domain.pen.AlderForDelingstall
 import java.time.LocalDate
-import java.time.Period
 
 object AlderForDelingstallBeregner {
     private val hoyesteAlderForDelingstall = Alder(70, 0)
     private val lavestMuligUttaksalder = 62
 
     fun bestemAldreForDelingstall(fodselsdato: LocalDate, uttaksdato: LocalDate): List<AlderForDelingstall> {
+
         val aarGammelVedUttak = uttaksdato.year - fodselsdato.year
 
         if (aarGammelVedUttak == lavestMuligUttaksalder) {
@@ -24,6 +24,11 @@ object AlderForDelingstallBeregner {
         if (aarGammelVedUttak >= hoyesteAlderForDelingstall.aar) {
             return listOf(AlderForDelingstall(hoyesteAlderForDelingstall, uttaksdato))
         }
-        return listOf(AlderForDelingstall(bestemAlderVedDato(fodselsdato, uttaksdato), uttaksdato))
+        val ufullstendigMaanedFratrekk = if (uttaksdato.dayOfMonth - fodselsdato.dayOfMonth == 0) 1 else 0
+
+        return listOf(AlderForDelingstall(
+            bestemAlderVedDato(fodselsdato, uttaksdato.minusMonths(ufullstendigMaanedFratrekk.toLong())),
+            uttaksdato)
+        )
     }
 }

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/afp/v1/AlderForDelingstallBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/afp/v1/AlderForDelingstallBeregnerTest.kt
@@ -34,4 +34,35 @@ class AlderForDelingstallBeregnerTest {
         assertEquals(64, alderListe[0].alder.aar)
         assertEquals(8, alderListe[0].alder.maaneder)
     }
+
+    @Test
+    fun `bestem alder ved uttaksalder 67 aar 0 maaneder`() {
+        val alderListe =
+            AlderForDelingstallBeregner.bestemAldreForDelingstall(LocalDate.of(2001, 1, 1), LocalDate.of(2068, 2, 1))
+        assertEquals(1, alderListe.size)
+        assertEquals(67, alderListe[0].alder.aar)
+        assertEquals(0, alderListe[0].alder.maaneder)
+    }
+
+    @Test
+    fun `bestem alder ved uttaksalder 64 aar 8 maaneder`() {
+        val alderListe =
+            AlderForDelingstallBeregner.bestemAldreForDelingstall(LocalDate.of(2001, 4, 1), LocalDate.of(2066, 1, 1))
+        assertEquals(1, alderListe.size)
+        assertEquals(64, alderListe[0].alder.aar)
+        assertEquals(8, alderListe[0].alder.maaneder)
+    }
+
+    @Test
+    fun `bestem alder ved uttaksalder 64 aar 9 maaneder`() {
+        val alderListe =
+            AlderForDelingstallBeregner.bestemAldreForDelingstall(LocalDate.of(2001, 4, 1), LocalDate.of(2066, 1, 15))
+        assertEquals(1, alderListe.size)
+        assertEquals(64, alderListe[0].alder.aar)
+        assertEquals(9, alderListe[0].alder.maaneder)
+    }
+
+
+
+
 }


### PR DESCRIPTION
Fikset feil delingstall for de som er født den første i måneden ved å subtrahere 1 måned dersom uttak og fødselsdato er den 1.