### PR TITLE
PEK-1150 senke grense for timeout til 30 sek

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/config/WebClientConfig.kt
@@ -180,7 +180,7 @@ class WebClientConfig {
 
     companion object {
         private const val CONNECT_TIMEOUT_MILLIS = 3000
-        const val READ_TIMEOUT_SECONDS = 45
+        const val READ_TIMEOUT_SECONDS = 30
 
         fun addCorrelationId(
             next: ExchangeFunction,


### PR DESCRIPTION
Senker grense til timeout for alle webclienter i appen, fordi 30 sekunder er veldig veldig høy terskel, og fordi alle tjenester burde respondere i hvert fall under 1-2 sekunder.