### PR TITLE
Pek 1324 sperre

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/request/SimulerTjenestepensjonRequestDto.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/dto/request/SimulerTjenestepensjonRequestDto.kt
@@ -11,7 +11,8 @@ data class SimulerTjenestepensjonRequestDto(
     val brukerBaOmAfp: Boolean,
     val epsPensjon: Boolean,
     val eps2G: Boolean,
-    val fremtidigeInntekter: List<SimulerTjenestepensjonFremtidigInntektDto>? = null //kun i V2
+    val fremtidigeInntekter: List<SimulerTjenestepensjonFremtidigInntektDto>? = null, //kun i V2
+    val erApoteker: Boolean
 )
 
 data class LoggableSimulerTjenestepensjonRequestDto(

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
@@ -30,7 +30,7 @@ class TjenestepensjonV2025Service(
 
         val tpOrdningerNavn = tpOrdninger.map { it.navn }
 
-        if (request.erApoteker && request.foedselsdato.year < 1963) return tpOrdningerNavn to Result.failure(TpOrdningStoettesIkkeException("Apoteker"))
+        if (request.erApoteker || request.foedselsdato.year < 1963) return tpOrdningerNavn to Result.failure(TpOrdningStoettesIkkeException("Apoteker"))
 
         val sisteOrdningerNr = finnSisteTpOrdningService.finnSisteOrdningKandidater(tpOrdninger)
         if (sisteOrdningerNr.isEmpty()) {

--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/TjenestepensjonV2025Service.kt
@@ -29,6 +29,9 @@ class TjenestepensjonV2025Service(
 
 
         val tpOrdningerNavn = tpOrdninger.map { it.navn }
+
+        if (request.erApoteker && request.foedselsdato.year < 1963) return tpOrdningerNavn to Result.failure(TpOrdningStoettesIkkeException("Apoteker"))
+
         val sisteOrdningerNr = finnSisteTpOrdningService.finnSisteOrdningKandidater(tpOrdninger)
         if (sisteOrdningerNr.isEmpty()) {
             return emptyList<String>() to Result.failure(BrukerErIkkeMedlemException())

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapperTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapperTest.kt
@@ -59,7 +59,8 @@ class KLPMapperTest {
                 SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2025, 2, 1), 4),
                 SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2026, 3, 1), 5),
                 SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2027, 4, 1), 6)
-            )
+            ),
+            erApoteker = false
         )
 
         val result: KLPSimulerTjenestepensjonRequest = KLPMapper.mapToRequest(request)

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapperTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapperTest.kt
@@ -54,7 +54,8 @@ class SPKMapperTest {
             eps2G = true,
             brukerBaOmAfp = true,
             uttaksdato = uttaksdato,
-            foedselsdato = LocalDate.of(1990, 1, 1)
+            foedselsdato = LocalDate.of(1990, 1, 1),
+            erApoteker = false
         )
 
         val result: SPKSimulerTjenestepensjonRequest = SPKMapper.mapToRequest(request)
@@ -91,7 +92,8 @@ class SPKMapperTest {
             eps2G = true,
             brukerBaOmAfp = false,
             uttaksdato = uttaksdato,
-            foedselsdato = LocalDate.of(1990, 1, 1)
+            foedselsdato = LocalDate.of(1990, 1, 1),
+            erApoteker = false
         )
 
         val result: SPKSimulerTjenestepensjonRequest = SPKMapper.mapToRequest(request)
@@ -133,7 +135,8 @@ class SPKMapperTest {
                 SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2025, 2, 1), 4),
                 SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2026, 3, 1), 5),
                 SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2027, 4, 1), 6)
-            )
+            ),
+            erApoteker = false
         )
 
         val result: SPKSimulerTjenestepensjonRequest = SPKMapper.mapToRequest(request)


### PR DESCRIPTION
Lagt til en sperre slik at de som er apotekere eller født før 1963 kun får liste med tp-ordninger