### PR TITLE
Revert "PEK-1430 Legg til siste inntekt som fjorårets inntekt og årets inntekt"

### DIFF
--- a/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
+++ b/src/main/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapper.kt
@@ -15,15 +15,8 @@ object KLPMapper {
     const val PROVIDER_FULLT_NAVN = "Kommunal Landspensjonskasse"
     const val ANNEN_TP_ORDNING_BURDE_SIMULERE = "IKKE_SISTE_ORDNING"
 
-    fun mapToRequest(request: SimulerTjenestepensjonRequestDto): KLPSimulerTjenestepensjonRequest {
-        val fremtidigeInntekter: MutableList<FremtidigInntekt> = mutableListOf(opprettNaaverendeInntektFoerUttak(request))
-        fremtidigeInntekter.addAll(request.fremtidigeInntekter?.map {
-            FremtidigInntekt(
-                fraOgMedDato = it.fraOgMed,
-                arligInntekt = it.aarligInntekt
-            )
-        } ?: emptyList())
-        return KLPSimulerTjenestepensjonRequest(
+    fun mapToRequest(request: SimulerTjenestepensjonRequestDto) =
+        KLPSimulerTjenestepensjonRequest(
             personId = request.pid,
             uttaksListe = listOf(
                 Uttak(
@@ -32,19 +25,16 @@ object KLPMapper {
                     uttaksgrad = 100
                 )
             ),
-            fremtidigInntektsListe = fremtidigeInntekter,
+            fremtidigInntektsListe = request.fremtidigeInntekter.orEmpty().map {
+                FremtidigInntekt(
+                    fraOgMedDato = it.fraOgMed,
+                    arligInntekt = it.aarligInntekt
+                )
+            },
             arIUtlandetEtter16 = request.aarIUtlandetEtter16,
             epsPensjon = request.epsPensjon,
             eps2G = request.eps2G,
         )
-    }
-
-    private fun opprettNaaverendeInntektFoerUttak(request: SimulerTjenestepensjonRequestDto) = FremtidigInntekt(
-        fraOgMedDato = fjorAarSomManglerOpptjeningIPopp(),
-        arligInntekt = request.sisteInntekt
-    )
-
-    private fun fjorAarSomManglerOpptjeningIPopp(): LocalDate = LocalDate.now().minusYears(1).withDayOfYear(1)
 
     fun mapToLoggableRequestDto(dto: SimulerTjenestepensjonRequestDto) =
         LoggableSimulerTjenestepensjonRequestDto(
@@ -56,6 +46,8 @@ object KLPMapper {
             eps2G = dto.eps2G,
             fremtidigeInntekter = dto.fremtidigeInntekter
         )
+
+    private fun aarUtenRegistrertInntektHosSkatteetaten(): LocalDate = LocalDate.now().minusYears(2).withDayOfYear(1)
 
     fun mapToResponse(response: KLPSimulerTjenestepensjonResponse, dto: LoggableSimulerTjenestepensjonRequestDto? = null): SimulertTjenestepensjon {
         log.info { "Mapping response from KLP $response" }

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapperTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/klp/KLPMapperTest.kt
@@ -71,13 +71,10 @@ class KLPMapperTest {
 
     @Test
     fun `map request to klp request`() {
-        val foersteJanuarIAar = LocalDate.now().withMonth(1).withDayOfMonth(1)
-        val naavaerendeAar = foersteJanuarIAar.year
-        val uttaksdato = LocalDate.of(naavaerendeAar + 1, 2, 1)
-        val sisteInntekt = 100000
+        val uttaksdato = LocalDate.of(2025, 2, 1)
         val request = SimulerTjenestepensjonRequestDto(
             pid = "12345678901",
-            sisteInntekt = sisteInntekt,
+            sisteInntekt = 100000,
             aarIUtlandetEtter16 = 3,
             epsPensjon = true,
             eps2G = true,
@@ -85,9 +82,9 @@ class KLPMapperTest {
             uttaksdato = uttaksdato,
             foedselsdato = LocalDate.of(1990, 1, 1),
             fremtidigeInntekter = listOf(
-                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(naavaerendeAar, 2, 1), 4),
-                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(naavaerendeAar + 1, 3, 1), 5),
-                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(naavaerendeAar + 2, 4, 1), 6)
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2025, 2, 1), 4),
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2026, 3, 1), 5),
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2027, 4, 1), 6)
             ),
             erApoteker = false
         )
@@ -98,14 +95,12 @@ class KLPMapperTest {
         assertEquals(1, result.uttaksListe.size)
         assertEquals("ALLE", result.uttaksListe[0].ytelseType)
         assertEquals(uttaksdato, result.uttaksListe[0].fraOgMedDato)
-        assertEquals(sisteInntekt, result.fremtidigInntektsListe[0].arligInntekt)
-        assertEquals(foersteJanuarIAar.minusYears(1), result.fremtidigInntektsListe[0].fraOgMedDato)
-        assertEquals(request.fremtidigeInntekter!![0].aarligInntekt, result.fremtidigInntektsListe[1].arligInntekt)
-        assertEquals(request.fremtidigeInntekter[0].fraOgMed, result.fremtidigInntektsListe[1].fraOgMedDato)
-        assertEquals(request.fremtidigeInntekter[1].aarligInntekt, result.fremtidigInntektsListe[2].arligInntekt)
-        assertEquals(request.fremtidigeInntekter[1].fraOgMed, result.fremtidigInntektsListe[2].fraOgMedDato)
-        assertEquals(request.fremtidigeInntekter[2].aarligInntekt, result.fremtidigInntektsListe[3].arligInntekt)
-        assertEquals(request.fremtidigeInntekter[2].fraOgMed, result.fremtidigInntektsListe[3].fraOgMedDato)
+        assertEquals(request.fremtidigeInntekter!![0].aarligInntekt, result.fremtidigInntektsListe[0].arligInntekt)
+        assertEquals(request.fremtidigeInntekter!![0].fraOgMed, result.fremtidigInntektsListe[0].fraOgMedDato)
+        assertEquals(request.fremtidigeInntekter!![1].aarligInntekt, result.fremtidigInntektsListe[1].arligInntekt)
+        assertEquals(request.fremtidigeInntekter!![1].fraOgMed, result.fremtidigInntektsListe[1].fraOgMedDato)
+        assertEquals(request.fremtidigeInntekter!![2].aarligInntekt, result.fremtidigInntektsListe[2].arligInntekt)
+        assertEquals(request.fremtidigeInntekter!![2].fraOgMed, result.fremtidigInntektsListe[2].fraOgMedDato)
         assertEquals(request.aarIUtlandetEtter16, result.arIUtlandetEtter16)
         assertTrue(result.epsPensjon)
         assertTrue(result.eps2G)

--- a/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapperTest.kt
+++ b/src/test/kotlin/no/nav/tjenestepensjon/simulering/v2025/tjenestepensjon/v1/service/spk/SPKMapperTest.kt
@@ -121,13 +121,10 @@ class SPKMapperTest {
 
     @Test
     fun `map request hvor bruker har ulike fremtidige inntekter`() {
-        val foersteJanuarIAar = LocalDate.now().withMonth(1).withDayOfMonth(1)
-        val naavaerendeAar = foersteJanuarIAar.year
-        val uttaksdato = LocalDate.of(naavaerendeAar + 1, 2, 1)
-        val sisteInntekt = 100000
+        val uttaksdato = LocalDate.of(2025, 2, 1)
         val request = SimulerTjenestepensjonRequestDto(
             pid = "12345678901",
-            sisteInntekt = sisteInntekt,
+            sisteInntekt = 100000,
             aarIUtlandetEtter16 = 3,
             epsPensjon = true,
             eps2G = true,
@@ -135,18 +132,19 @@ class SPKMapperTest {
             uttaksdato = uttaksdato,
             foedselsdato = LocalDate.of(1990, 1, 1),
             fremtidigeInntekter = listOf(
-                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(naavaerendeAar, 2, 1), 4),
-                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(naavaerendeAar + 1, 3, 1), 5),
-                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(naavaerendeAar + 2, 4, 1), 6)        ),
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2025, 2, 1), 4),
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2026, 3, 1), 5),
+                SimulerTjenestepensjonFremtidigInntektDto(LocalDate.of(2027, 4, 1), 6)
+            ),
             erApoteker = false
         )
 
         val result: SPKSimulerTjenestepensjonRequest = SPKMapper.mapToRequest(request)
 
-        assertEquals(request.pid, result.personId)
+        assertEquals("12345678901", result.personId)
         assertEquals(4, result.fremtidigInntektListe.size)
         assertEquals(request.sisteInntekt, result.fremtidigInntektListe[0].aarligInntekt)
-        assertEquals(foersteJanuarIAar.minusYears(1),result.fremtidigInntektListe[0].fraOgMedDato)
+        assertTrue(result.fremtidigInntektListe[0].fraOgMedDato.isBefore(LocalDate.now().minusYears(1)))
         assertEquals(4, result.fremtidigInntektListe[1].aarligInntekt)
         assertEquals(LocalDate.of(2025, 2, 1), result.fremtidigInntektListe[1].fraOgMedDato)
         assertEquals(5, result.fremtidigInntektListe[2].aarligInntekt)


### PR DESCRIPTION
Reverts navikt/tjenestepensjon-simulering#297

KLP takler ofte ikke fjorårets inntekt inne i fremtidige inntekter